### PR TITLE
Feature/member authority entity

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/security/entity/BaseTimeEntity.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/entity/BaseTimeEntity.kt
@@ -1,26 +1,25 @@
 package com.friends.security.entity
 
-import jakarta.persistence.Column
-import jakarta.persistence.MappedSuperclass
-import jakarta.persistence.PrePersist
-import jakarta.persistence.PreUpdate
+import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
 @MappedSuperclass
-open class BaseTimeEntity (
-    @Column(updatable = false)
-    var createdAt: LocalDateTime = LocalDateTime.now(),
-    var updatedAt : LocalDateTime = LocalDateTime.now()
-){
-    @PrePersist
-    fun prePersist(){
-        val now = LocalDateTime.now()
-        createdAt = now
-        updatedAt = now
-    }
-
-    @PreUpdate
-    fun preUpdate(){
-        updatedAt = LocalDateTime.now()
-    }
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    lateinit var createdAt: LocalDateTime
+        protected set
 }
+
+@MappedSuperclass
+abstract class BaseModifiableEntity : BaseTimeEntity() {
+    @LastModifiedDate
+    @Column(nullable = false)
+    lateinit var updatedAt: LocalDateTime
+        protected set
+}
+

--- a/friends_server/src/main/kotlin/com/friends/security/entity/BaseTimeEntity.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/entity/BaseTimeEntity.kt
@@ -1,0 +1,26 @@
+package com.friends.security.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.PrePersist
+import jakarta.persistence.PreUpdate
+import java.time.LocalDateTime
+
+@MappedSuperclass
+open class BaseTimeEntity (
+    @Column(updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+    var updatedAt : LocalDateTime = LocalDateTime.now()
+){
+    @PrePersist
+    fun prePersist(){
+        val now = LocalDateTime.now()
+        createdAt = now
+        updatedAt = now
+    }
+
+    @PreUpdate
+    fun preUpdate(){
+        updatedAt = LocalDateTime.now()
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/security/entity/MemberEnums.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/entity/MemberEnums.kt
@@ -1,0 +1,10 @@
+package com.friends.security.entity
+
+enum class OAuth2Provider {
+    GOOGLE,
+    NAVER
+}
+
+enum class Role {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
@@ -4,7 +4,7 @@ import jakarta.persistence.*
 
 @Entity
 class Member(
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     val id: Long? = null,  // id는 불변 값으로 설정하여 JPA에서 자동으로 할당
     var name: String,
@@ -85,7 +85,7 @@ class Member(
 
 @Entity
 class Authority(
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "authority_id")
     val id: Long? = null,  // id는 불변 값으로 설정하여 JPA에서 자동으로 할당
     @Enumerated(EnumType.STRING)

--- a/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
@@ -14,7 +14,7 @@ class Member(
 
     @Enumerated(EnumType.STRING)
     var oauth2Provider: OAuth2Provider,
-    var oauth2Id: Int,
+
     var imageUrl: String,
 
     @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], orphanRemoval = true)
@@ -39,7 +39,6 @@ class Member(
                 email = email,
                 password = password,
                 oauth2Provider = oauth2Provider,
-                oauth2Id = oauth2Id,
                 imageUrl = imageUrl
             ).apply {
                 addAuthority(Role.ROLE_USER)  // 기본 권한을 사용자 권한으로 설정
@@ -63,7 +62,6 @@ class Member(
                 email = email,
                 password = password,
                 oauth2Provider = oauth2Provider,
-                oauth2Id = oauth2Id,
                 imageUrl = imageUrl
             ).apply {
                 addAuthority(Role.ROLE_USER)  // 기본 권한으로 사용자 권한 추가

--- a/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.*
 @Entity
 class Member(
     @Id @GeneratedValue
+    @Column(name = "member_id")
     val id: Long? = null,  // id는 불변 값으로 설정하여 JPA에서 자동으로 할당
     var name: String,
 
@@ -85,6 +86,7 @@ class Member(
 @Entity
 class Authority(
     @Id @GeneratedValue
+    @Column(name = "authority_id")
     val id: Long? = null,  // id는 불변 값으로 설정하여 JPA에서 자동으로 할당
     @Enumerated(EnumType.STRING)
     var role: Role,

--- a/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
@@ -20,7 +20,7 @@ class Member(
 
     @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], orphanRemoval = true)
     val authorities: MutableList<Authority> = ArrayList()  // 권한 리스트는 기본적으로 비어 있는 리스트로 초기화
-) : BaseTimeEntity() {
+) : BaseModifiableEntity() {
 
     companion object {
         /**
@@ -94,4 +94,4 @@ class Authority(
     @ManyToOne
     @JoinColumn(name = "member_id")
     var member: Member
-) : BaseTimeEntity()
+) : BaseModifiableEntity()

--- a/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/entity/memberEntities.kt
@@ -1,0 +1,97 @@
+package com.friends.security.entity
+
+import jakarta.persistence.*
+
+@Entity
+class Member(
+    @Id @GeneratedValue
+    val id: Long? = null,  // id는 불변 값으로 설정하여 JPA에서 자동으로 할당
+    var name: String,
+
+    @Column(unique = true, updatable = false) // 이메일은 중복되지 않아야 하며 수정되지 않아야 합니다.
+    val email: String,
+    var password: String,
+
+    @Enumerated(EnumType.STRING)
+    var oauth2Provider: OAuth2Provider,
+    var oauth2Id: Int,
+    var imageUrl: String,
+
+    @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val authorities: MutableList<Authority> = ArrayList()  // 권한 리스트는 기본적으로 비어 있는 리스트로 초기화
+) : BaseTimeEntity() {
+
+    companion object {
+        /**
+         * 일반 사용자 생성 메서드
+         * 권한을 ROLE_USER로 초기화하여 Member 객체를 반환합니다.
+         */
+        fun createUser(
+            name: String,
+            email: String,
+            password: String,
+            oauth2Provider: OAuth2Provider,
+            oauth2Id: Int,
+            imageUrl: String
+        ): Member {
+            return Member(
+                name = name,
+                email = email,
+                password = password,
+                oauth2Provider = oauth2Provider,
+                oauth2Id = oauth2Id,
+                imageUrl = imageUrl
+            ).apply {
+                addAuthority(Role.ROLE_USER)  // 기본 권한을 사용자 권한으로 설정
+            }
+        }
+
+        /**
+         * 관리자 생성 메서드
+         * 권한을 ROLE_USER와 ROLE_ADMIN으로 초기화하여 Member 객체를 반환합니다.
+         */
+        fun createAdmin(
+            name: String,
+            email: String,
+            password: String,
+            oauth2Provider: OAuth2Provider,
+            oauth2Id: Int,
+            imageUrl: String
+        ): Member {
+            return Member(
+                name = name,
+                email = email,
+                password = password,
+                oauth2Provider = oauth2Provider,
+                oauth2Id = oauth2Id,
+                imageUrl = imageUrl
+            ).apply {
+                addAuthority(Role.ROLE_USER)  // 기본 권한으로 사용자 권한 추가
+                addAuthority(Role.ROLE_ADMIN) // 관리자 권한 추가
+            }
+        }
+    }
+
+    /**
+     * 새로운 권한을 추가하는 메서드
+     * 중복된 권한을 방지하고 권한 추가 로직을 캡슐화합니다.
+     */
+    fun addAuthority(role: Role) {
+        // 이미 동일한 권한이 존재하는지 검사 후 추가
+        if (authorities.none { it.role == role }) {
+            authorities.add(Authority(role = role, member = this))
+        }
+    }
+}
+
+@Entity
+class Authority(
+    @Id @GeneratedValue
+    val id: Long? = null,  // id는 불변 값으로 설정하여 JPA에서 자동으로 할당
+    @Enumerated(EnumType.STRING)
+    var role: Role,
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    var member: Member
+) : BaseTimeEntity()


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- `@MappedSuperclass` 를 이용해 생성 시간, 수정 시간을 포함한 BaseEntity 를 구현하였습니다.
- MemberEntity 와 AuthorityEntity를 구현하였습니다.
- Member 와 Autority 를 일대다로 매핑하고 영속성 전이를 설정하였습니다.
- Member 에 유저를 생성하는 메서드와 관리자를 생성하는 메서드를 `companion object` 를 이용하여 구현하였습니다.

### 🔗 관련 이슈
- close #8 

### 💬 기타 참고 사항
- `companion object`(Java 로 치면 `static` 인 메소드를 구현할 수 있는 방법)을 이용해서 펙토리 메서드 패턴을 구현하였습니다.
Entity 에서 커스텀 생성자를 만들고 JPA 가 사용할 수 있도록 기본 생성자도 추가로 만드는 것보다
`companion object` 를 사용하는게 의미부여(method 의 이름 지정 가능), 확장성 측면(추가로 method 를 만들 때 기본 생성자 생성을 고려하지 않아도 됌) 에서 좋은 패턴이라고 생각했는데, 다른 분들의 생각도 궁금합니다.

- 속성 값의 길이 제한, 포멧 검사 등을 설정하지 않았습니다. 
앤티티 설계 초기 단계에서는 되려 복잡해질까봐 최소한의 설정만 하였는데, 다른 분들의 의견도 궁금합니다.