### PR TITLE
Feature/oauth

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/FRI-BACKEND.iml
+++ b/.idea/FRI-BACKEND.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_21" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="21" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/friends_server" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/friends_server" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Kotlin2JsCompilerArguments">
+    <option name="moduleKind" value="plain" />
+  </component>
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="1.8" />
+  </component>
+  <component name="KotlinCommonCompilerArguments">
+    <option name="apiVersion" value="1.9" />
+    <option name="languageVersion" value="1.9" />
+  </component>
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.9.25" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/friends_server" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="21" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/FRI-BACKEND.iml" filepath="$PROJECT_DIR$/.idea/FRI-BACKEND.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/friends_server/build.gradle.kts
+++ b/friends_server/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation ("io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64")
+
 //    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     // Kotlin
@@ -60,6 +62,7 @@ dependencies {
     testImplementation("io.kotest:kotest-runner-junit5:5.9.0")
     testImplementation("io.kotest:kotest-assertions-core:5.9.0")
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+
 }
 
 kotlin {

--- a/friends_server/build.gradle.kts
+++ b/friends_server/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+//    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     // Kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/friends_server/src/main/kotlin/com/friends/config/OAuthConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/OAuthConfig.kt
@@ -1,0 +1,8 @@
+package com.friends.config
+
+class OAuthConfig (
+    val clientId: String,
+    val clientSecret: String,
+    val redirectUri: String,
+    val tokenUri: String,
+)

--- a/friends_server/src/main/kotlin/com/friends/config/WebClientConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/WebClientConfig.kt
@@ -1,0 +1,13 @@
+package com.friends.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfig {
+
+    @Bean
+    fun webClient(): WebClient.Builder = WebClient.builder()
+
+}

--- a/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
@@ -1,82 +1,25 @@
 package com.friends.oauth2.controller
 
-import com.friends.config.OAuthConfig
+import com.friends.oauth2.service.OAuth2Service
 import com.friends.security.entity.OAuth2Provider
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
 
 @RestController
 @RequestMapping("/api/auth")
-class OAuth2Controller (
-    private val webClient: WebClient.Builder
+class OAuth2Controller(
+    private val oAuth2Service: OAuth2Service
 ) {
-
-    @Value("\${google.client-id}")
-    private lateinit var googleClientId: String
-
-    @Value("\${google.client-secret}")
-    private lateinit var googleClientSecret: String
-
-    @Value("\${google.redirect-uri}")
-    private lateinit var googleRedirectUri: String
-
-    @Value("\${naver.client-id}")
-    private lateinit var naverClientId: String
-
-    @Value("\${naver.client-secret}")
-    private lateinit var naverClientSecret: String
-
-    @Value("\${naver.redirect-uri}")
-    private lateinit var naverRedirectUri: String
-
-
     /*
     * 0. 인가코드 발급 후 액세스 토큰 요청
     */
 
     @PostMapping("/oauth2-token")
     fun requestAccessToken(@RequestParam code: String, @RequestParam provider: OAuth2Provider): Mono<ResponseEntity<String>>{
-
         println("인가코드: $code, 공급자: $provider")
-
-        val config = when (provider) {
-            OAuth2Provider.GOOGLE -> OAuthConfig(
-                googleClientId,
-                googleClientSecret,
-                googleRedirectUri,
-                "https://oauth2.googleapis.com/token"
-            )
-
-            OAuth2Provider.NAVER -> OAuthConfig(
-                naverClientId,
-                naverClientSecret,
-                naverRedirectUri,
-                "https://nid.naver.com/oauth2.0/token"
-            )
-        }
-
-        return webClient.build()
-            .post()
-            .uri(config.tokenUri)
-            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-            .bodyValue(
-                "code=$code&client_id=${config.clientId}&client_secret=${config.clientSecret}&redirect_uri=${config.redirectUri}&grant_type=authorization_code"
-            )
-            .retrieve()
-            .bodyToMono(String::class.java)
-            .map { tokenResponse ->
-                println("액세스 토큰 요청 성공: $tokenResponse")
-                ResponseEntity.ok("Access Token Response: $tokenResponse")
-            }
-            .onErrorResume { e ->
-                println("액세스 토큰 요청 실패: ${e.message}")
-                Mono.just(ResponseEntity.badRequest().body("Failed to get token"))
-            }
+        return oAuth2Service.requestAccessToken(code, provider)
     }
 
     /*
@@ -84,28 +27,7 @@ class OAuth2Controller (
     */
     @GetMapping("/oauth2-data")
     fun getUserData(@RequestParam accessToken: String, @RequestParam provider: OAuth2Provider): Mono<ResponseEntity<String>> {
-
-        val userInfoUri = when (provider) {
-            OAuth2Provider.GOOGLE -> "https://www.googleapis.com/oauth2/v2/userinfo"
-            OAuth2Provider.NAVER -> "https://openapi.naver.com/v1/nid/me"
-        }
-
-        return webClient.build()
-            .get()
-            .uri(userInfoUri) { uriBuilder ->
-                uriBuilder.queryParam("access_token", accessToken).build()
-            }
-            .retrieve()
-            .bodyToMono(String::class.java)
-            .map { userDataResponse ->
-                println("사용자 데이터 요청 성공: $userDataResponse")
-                ResponseEntity.ok("User data Response: $userDataResponse")
-            }
-            .onErrorResume { e ->
-                println("사용자 데이터 요청 실패: ${e.message}")
-                Mono.just(ResponseEntity.status(500).body("Failed to get user data"))
-            }
-
+        return oAuth2Service.getUserData(accessToken, provider)
     }
 }
 

--- a/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
@@ -1,11 +1,19 @@
 package com.friends.oauth2.controller
 
+import com.friends.security.entity.OAuth2Provider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
+
+data class OAuthConfig(
+    val clientId: String,
+    val clientSecret: String,
+    val redirectUri: String,
+    val tokenUri: String,
+)
 
 @RestController
 @RequestMapping("/api/auth")
@@ -14,33 +22,58 @@ class OAuth2Controller (
 ) {
 
     @Value("\${google.client-id}")
-    private lateinit var clientId: String
+    private lateinit var googleClientId: String
 
     @Value("\${google.client-secret}")
-    private lateinit var clientSecret: String
+    private lateinit var googleClientSecret: String
 
     @Value("\${google.redirect-uri}")
-    private lateinit var redirectUri: String
+    private lateinit var googleRedirectUri: String
+
+    @Value("\${naver.client-id}")
+    private lateinit var naverClientId: String
+
+    @Value("\${naver.client-secret}")
+    private lateinit var naverClientSecret: String
+
+    @Value("\${naver.redirect-uri}")
+    private lateinit var naverRedirectUri: String
+
 
     /*
     * 0. 인가코드 발급 후 액세스 토큰 요청
     */
 
     @PostMapping("/oauth2-token")
-    fun requestAccessToken(@RequestParam code: String): Mono<ResponseEntity<String>>{
+    fun requestAccessToken(@RequestParam code: String, @RequestParam provider: OAuth2Provider): Mono<ResponseEntity<String>>{
 
         //client가 넘겨준 인가코드
-        println("인가코드: $code")
+        println("인가코드: $code, 공급자: $provider")
 
-        val tokenUri = "https://oauth2.googleapis.com/token"
+//        val tokenUri = "https://oauth2.googleapis.com/token"
 
-        //access token 발급 요청 생성
+        val config = when (provider) {
+            OAuth2Provider.GOOGLE -> OAuthConfig(
+                googleClientId,
+                googleClientSecret,
+                googleRedirectUri,
+                "https://oauth2.googleapis.com/token"
+            )
+
+            OAuth2Provider.NAVER -> OAuthConfig(
+                naverClientId,
+                naverClientSecret,
+                naverRedirectUri,
+                "https://nid.naver.com/oauth2.0/token"
+            )
+        }
+
         return webClient.build()
             .post()
-            .uri(tokenUri)
+            .uri(config.tokenUri)
             .contentType(MediaType.APPLICATION_FORM_URLENCODED)
             .bodyValue(
-                "code=$code&client_id=$clientId&client_secret=$clientSecret&redirect_uri=$redirectUri&grant_type=authorization_code"
+                "code=$code&client_id=${config.clientId}&client_secret=${config.clientSecret}&redirect_uri=${config.redirectUri}&grant_type=authorization_code"
             )
             .retrieve()
             .bodyToMono(String::class.java)
@@ -58,8 +91,12 @@ class OAuth2Controller (
     * 1. accessToken을 통한 user data 넘겨받기
     */
     @GetMapping("/oauth2-data")
-    fun getUserData(@RequestParam accessToken: String): Mono<ResponseEntity<String>> {
-        val userInfoUri = "https://www.googleapis.com/oauth2/v2/userinfo"
+    fun getUserData(@RequestParam accessToken: String, @RequestParam provider: OAuth2Provider): Mono<ResponseEntity<String>> {
+
+        val userInfoUri = when (provider) {
+            OAuth2Provider.GOOGLE -> "https://www.googleapis.com/oauth2/v2/userinfo"
+            OAuth2Provider.NAVER -> "https://openapi.naver.com/v1/nid/me"
+        }
 
         return webClient.build()
             .get()

--- a/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
@@ -47,10 +47,7 @@ class OAuth2Controller (
     @PostMapping("/oauth2-token")
     fun requestAccessToken(@RequestParam code: String, @RequestParam provider: OAuth2Provider): Mono<ResponseEntity<String>>{
 
-        //client가 넘겨준 인가코드
         println("인가코드: $code, 공급자: $provider")
-
-//        val tokenUri = "https://oauth2.googleapis.com/token"
 
         val config = when (provider) {
             OAuth2Provider.GOOGLE -> OAuthConfig(

--- a/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
@@ -1,0 +1,82 @@
+package com.friends.oauth2.controller
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/api/auth")
+class OAuth2Controller (
+    private val webClient: WebClient.Builder
+) {
+
+    @Value("\${google.client-id}")
+    private lateinit var clientId: String
+
+    @Value("\${google.client-secret}")
+    private lateinit var clientSecret: String
+
+    @Value("\${google.redirect-uri}")
+    private lateinit var redirectUri: String
+
+    /*
+    * 0. 인가코드 발급 후 액세스 토큰 요청
+    */
+
+    @PostMapping("/oauth2-token")
+    fun requestAccessToken(@RequestParam code: String): Mono<ResponseEntity<String>>{
+
+        //client가 넘겨준 인가코드
+        println("인가코드: $code")
+
+        val tokenUri = "https://oauth2.googleapis.com/token"
+
+        //access token 발급 요청 생성
+        return webClient.build()
+            .post()
+            .uri(tokenUri)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .bodyValue(
+                "code=$code&client_id=$clientId&client_secret=$clientSecret&redirect_uri=$redirectUri&grant_type=authorization_code"
+            )
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .map { tokenResponse ->
+                println("액세스 토큰 요청 성공: $tokenResponse")
+                ResponseEntity.ok("Access Token Response: $tokenResponse")
+            }
+            .onErrorResume { e ->
+                println("액세스 토큰 요청 실패: ${e.message}")
+                Mono.just(ResponseEntity.badRequest().body("Failed to get token"))
+            }
+    }
+
+    /*
+    * 1. accessToken을 통한 user data 넘겨받기
+    */
+    @GetMapping("/oauth2-data")
+    fun getUserData(@RequestParam accessToken: String): Mono<ResponseEntity<String>> {
+        val userInfoUri = "https://www.googleapis.com/oauth2/v2/userinfo"
+
+        return webClient.build()
+            .get()
+            .uri(userInfoUri) { uriBuilder ->
+                uriBuilder.queryParam("access_token", accessToken).build()
+            }
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .map { userDataResponse ->
+                println("사용자 데이터 요청 성공: $userDataResponse")
+                ResponseEntity.ok("User data Response: $userDataResponse")
+            }
+            .onErrorResume { e ->
+                println("사용자 데이터 요청 실패: ${e.message}")
+                Mono.just(ResponseEntity.status(500).body("Failed to get user data"))
+            }
+
+    }
+}
+

--- a/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/controller/OAuth2Controller.kt
@@ -1,5 +1,6 @@
 package com.friends.oauth2.controller
 
+import com.friends.config.OAuthConfig
 import com.friends.security.entity.OAuth2Provider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
@@ -8,12 +9,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 
-data class OAuthConfig(
-    val clientId: String,
-    val clientSecret: String,
-    val redirectUri: String,
-    val tokenUri: String,
-)
 
 @RestController
 @RequestMapping("/api/auth")

--- a/friends_server/src/main/kotlin/com/friends/oauth2/service/OAuth2Service.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/service/OAuth2Service.kt
@@ -1,9 +1,99 @@
 package com.friends.oauth2.service
 
+import com.friends.config.OAuthConfig
+import com.friends.security.entity.OAuth2Provider
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
 
 @Service
-class OAuth2Service {
+class OAuth2Service (
+    private val webClient: WebClient.Builder
+){
+
+    @Value("\${google.client-id}")
+    private lateinit var googleClientId: String
+
+    @Value("\${google.client-secret}")
+    private lateinit var googleClientSecret: String
+
+    @Value("\${google.redirect-uri}")
+    private lateinit var googleRedirectUri: String
+
+    @Value("\${naver.client-id}")
+    private lateinit var naverClientId: String
+
+    @Value("\${naver.client-secret}")
+    private lateinit var naverClientSecret: String
+
+    @Value("\${naver.redirect-uri}")
+    private lateinit var naverRedirectUri: String
+
+    /*
+    * access Token 발급 요청
+    * */
+    fun requestAccessToken(code: String, provider: OAuth2Provider): Mono<ResponseEntity<String>>{
+        val config = when(provider){
+            OAuth2Provider.GOOGLE -> OAuthConfig(
+                googleClientId,
+                googleClientSecret,
+                googleRedirectUri,
+                "https://oauth2.googleapis.com/token"
+            )
+            OAuth2Provider.NAVER -> OAuthConfig(
+                naverClientId,
+                naverClientSecret,
+                naverRedirectUri,
+                "https://nid.naver.com/oauth2.0/token"
+            )
+        }
+        return webClient.build()
+            .post()
+            .uri(config.tokenUri)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .bodyValue(
+                "code=$code&client_id=${config.clientId}&client_secret=${config.clientSecret}&redirect_uri=${config.redirectUri}&grant_type=authorization_code"
+            )
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .map { tokenResponse ->
+                println("액세스 토큰 요청 성공: $tokenResponse")
+                ResponseEntity.ok("Access Token Response: $tokenResponse")
+            }
+            .onErrorResume { e ->
+                println("액세스 토큰 요청 실패: ${e.message}")
+                Mono.just(ResponseEntity.badRequest().body("Failed to get token"))
+            }
+    }
+
+    /*
+    유저 데이터 요청
+    */
+    fun getUserData(accessToken: String, provider: OAuth2Provider): Mono<ResponseEntity<String>>{
+        val userInfoUri = when (provider) {
+            OAuth2Provider.GOOGLE -> "https://www.googleapis.com/oauth2/v2/userinfo"
+            OAuth2Provider.NAVER -> "https://openapi.naver.com/v1/nid/me"
+        }
+
+        return webClient.build()
+            .get()
+            .uri(userInfoUri) { uriBuilder ->
+                uriBuilder.queryParam("access_token", accessToken).build()
+            }
+            .retrieve()
+            .bodyToMono(String::class.java)
+            .map { userDataResponse ->
+                println("사용자 데이터 요청 성공: $userDataResponse")
+                ResponseEntity.ok("User data Response: $userDataResponse")
+            }
+            .onErrorResume { e ->
+                println("사용자 데이터 요청 실패: ${e.message}")
+                Mono.just(ResponseEntity.status(500).body("Failed to get user data"))
+            }
+    }
 
 
 

--- a/friends_server/src/main/kotlin/com/friends/oauth2/service/OAuth2Service.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/service/OAuth2Service.kt
@@ -1,0 +1,10 @@
+package com.friends.oauth2.service
+
+import org.springframework.stereotype.Service
+
+@Service
+class OAuth2Service {
+
+
+
+}

--- a/friends_server/src/main/resources/application.yml
+++ b/friends_server/src/main/resources/application.yml
@@ -37,3 +37,9 @@ logging:
       hibernate:
         SQL: debug
         type.descriptor.sql: trace
+
+
+google:
+  client-id: 71559751357-tis73qfauh5974vt84riukfmdgojspi0.apps.googleusercontent.com
+  client-secret: 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
+  redirect-uri: http://localhost:8080/oauth2/code/google

--- a/friends_server/src/main/resources/application.yml
+++ b/friends_server/src/main/resources/application.yml
@@ -39,7 +39,14 @@ logging:
         type.descriptor.sql: trace
 
 
+#oauth2
 google:
   client-id: 71559751357-tis73qfauh5974vt84riukfmdgojspi0.apps.googleusercontent.com
   client-secret: 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
   redirect-uri: http://localhost:8080/oauth2/code/google
+
+#project not yet
+naver:
+  client-id: 000
+  client-secret: 000
+  redirect-uri: 000


### PR DESCRIPTION
## 📝 Pull Request 내용

1. 인증 서버로 GOOGLE, NAVER를 provider와 Client로부터 받은 인가코드를 인자로 받아 `requestAccessToken ` (post)를 구현하였습니다.

2. AccessToken을 통해 User data를 넘겨받는 `getUserData`(get)을 구현하였습니다.

### 📑 변경 사항
- [x] OAuth2.0 구현 시 필요한 두가지 메서드가 포함된 클래스 작성하였습니다.
- [ ] WebClientConfig를 사용하여 통신을 진행합니다.
- [x] build.gradle.kt에 관련 webflux 의존성과 이에 대해 생기는 맥 에러 방지 의존성을 추가하였습니다.
- [x] application.yml에 구글/네이버 관련 프로젝트 설정 정보를 작성하고 있습니다.

### 🔗 관련 이슈
- #13 

### 💬 기타 참고 사항
- naver oauth2 프로젝트 미생성, 프론트엔드와 API 미연동이므로 아직 이슈 닫지 않겠습니다.
