### PR TITLE
Feature/email password auth

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
@@ -9,8 +9,8 @@ enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage
 
     // Auth API error 11000대
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, -11001, "유효하지 않은 토큰입니다."),
-    MISSING_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, -11001, "SocialAccessToken 이 존재하지 않습니다."),
     MISSING_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, -11002, "RefreshToken 이 존재하지 않습니다."),
+    MISSING_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, -11003, "SocialAccessToken 이 존재하지 않습니다."),
 
     // Member API error 12000대
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, -12001, "존재하지 않는 회원입니다."),

--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
@@ -4,12 +4,11 @@ import org.springframework.http.HttpStatus
 
 enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage: String) {
     // global error
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, -10000, "Invalid request"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, -10001, "Internal server error"),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, -10000, "적절하지 않은 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, -10001, "서버 내부 오류입니다."),
 
     // Auth API error 11000대
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, -11000, "유효하지 않은 RefreshToken 입니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, -11000, "유효하지 않은 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, -11001, "유효하지 않은 토큰입니다."),
     MISSING_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, -11001, "SocialAccessToken 이 존재하지 않습니다."),
     MISSING_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, -11002, "RefreshToken 이 존재하지 않습니다."),
 

--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
@@ -1,0 +1,18 @@
+package com.friends.common.exception
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage: String) {
+    // global error
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, -10000, "Invalid request"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, -10001, "Internal server error"),
+
+    // Auth API error 11000대
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, -11000, "유효하지 않은 RefreshToken 입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, -11000, "유효하지 않은 토큰입니다."),
+    MISSING_SOCIAL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, -11001, "SocialAccessToken 이 존재하지 않습니다."),
+    MISSING_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, -11002, "RefreshToken 이 존재하지 않습니다."),
+
+    // Member API error 12000대
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, -12001, "존재하지 않는 회원입니다."),
+}

--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorResponse.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorResponse.kt
@@ -1,0 +1,10 @@
+package com.friends.common.exception
+
+open class ErrorResponse private constructor(val code: Int, val errorMessage: String) {
+    companion object {
+        fun of(
+            errorCode: ErrorCode,
+            errorMessage: String?,
+        ) = ErrorResponse(errorCode.code, errorMessage ?: errorCode.errorMessage)
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorResponse.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorResponse.kt
@@ -1,6 +1,6 @@
 package com.friends.common.exception
 
-open class ErrorResponse private constructor(val code: Int, val errorMessage: String) {
+class ErrorResponse private constructor(val code: Int, val errorMessage: String) {
     companion object {
         fun of(
             errorCode: ErrorCode,

--- a/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
@@ -15,6 +15,7 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(InvalidJwtException::class)
     fun handleInvalidJwtException(ex: InvalidJwtException): ResponseEntity<Any> {
         log.error("Invalid JWT", ex)
-        return ResponseEntity.status(ex.httpStatus).body(ErrorResponse.of(ex.errorCode, ex.message))
+        return ResponseEntity.status(ex.errorCode.httpStatus)
+            .body(ErrorResponse.of(ex.errorCode, ex.message))
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,21 @@
+package com.friends.common.exception
+
+import com.friends.security.securityException.InvalidJwtException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+@RestControllerAdvice // @ControllerAdvice와 @ResponseBody를 결합한 것
+class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
+
+    private val log: Logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    @ExceptionHandler(InvalidJwtException::class)
+    fun handleInvalidJwtException(ex: InvalidJwtException): ResponseEntity<Any> {
+        log.error("Invalid JWT", ex)
+        return ResponseEntity.status(ex.httpStatus).body(ErrorResponse.of(ex.errorCode, ex.message))
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
@@ -10,7 +10,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 @RestControllerAdvice // @ControllerAdvice와 @ResponseBody를 결합한 것
 class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
-
     private val log: Logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
 
     @ExceptionHandler(InvalidJwtException::class)

--- a/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
@@ -1,0 +1,65 @@
+package com.friends.config
+
+import com.friends.member.entity.Role
+import com.friends.security.filter.JwtFilter
+import com.friends.security.securityException.JwtFilterAccessDeniedHandler
+import com.friends.security.securityException.JwtFilterAuthenticationEntryPoint
+import com.friends.security.userDetails.CustomUserDetailsService
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+@EnableWebSecurity
+class SpringSecurityConfig(
+    private val customUserDetailsService: CustomUserDetailsService,
+    private val jwtFilterAccessDeniedHandler: JwtFilterAccessDeniedHandler,
+    private val jwtFilterAuthenticationEntryPoint: JwtFilterAuthenticationEntryPoint,
+    private val jwtFilter: JwtFilter,
+) {
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+
+    @Bean
+    fun defaultSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http.csrf { it.disable() }
+
+        http
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .exceptionHandling {
+                it
+                    .accessDeniedHandler(jwtFilterAccessDeniedHandler)
+                    .authenticationEntryPoint(jwtFilterAuthenticationEntryPoint)
+            }
+
+        http.authorizeHttpRequests {
+            it
+                .requestMatchers("/api/user/**")
+                .hasAuthority(Role.ROLE_USER.name)
+                .requestMatchers("/api/admin/**")
+                .hasAuthority(Role.ROLE_ADMIN.name)
+                .anyRequest()
+                .permitAll()
+        }
+
+        return http.build()
+    }
+
+    @Bean
+    fun authenticationProvider(): DaoAuthenticationProvider =
+        DaoAuthenticationProvider().apply {
+            setUserDetailsService(customUserDetailsService)
+            setPasswordEncoder(passwordEncoder())
+        }
+
+    @Bean
+    fun authenticationManager(authConfig: AuthenticationConfiguration): AuthenticationManager = authConfig.authenticationManager
+}

--- a/friends_server/src/main/kotlin/com/friends/member/entity/MemberEntities.kt
+++ b/friends_server/src/main/kotlin/com/friends/member/entity/MemberEntities.kt
@@ -26,8 +26,8 @@ class Member(
     val email: String,
     var password: String,
     @Enumerated(EnumType.STRING)
-    var oauth2Provider: OAuth2Provider,
-    var imageUrl: String,
+    var oauth2Provider: OAuth2Provider?,
+    var imageUrl: String?,
     // 권한 리스트는 기본적으로 비어 있는 리스트로 초기화
     @OneToMany(mappedBy = "member", cascade = [CascadeType.ALL], orphanRemoval = true)
     val authorities: MutableList<Authority> = ArrayList(),
@@ -41,8 +41,8 @@ class Member(
             name: String,
             email: String,
             password: String,
-            oauth2Provider: OAuth2Provider,
-            imageUrl: String,
+            oauth2Provider: OAuth2Provider? = null,
+            imageUrl: String? = null,
         ): Member =
             Member(
                 name = name,
@@ -62,8 +62,8 @@ class Member(
             name: String,
             email: String,
             password: String,
-            oauth2Provider: OAuth2Provider,
-            imageUrl: String,
+            oauth2Provider: OAuth2Provider? = null,
+            imageUrl: String? = null,
         ): Member =
             Member(
                 name = name,

--- a/friends_server/src/main/kotlin/com/friends/member/entity/MemberEntities.kt
+++ b/friends_server/src/main/kotlin/com/friends/member/entity/MemberEntities.kt
@@ -18,7 +18,8 @@ class Member(
     // id는 불변 값으로 설정하여 JPA에서 자동으로 할당
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
-    val id: Long = 0L, // IDENTITY가 1부터 시작하므로, 초기 값인 0L은 무시되며, 엔티티가 저장될 때 데이터베이스가 올바른 자동 증가 값을 할당
+    val id: Long = 0L,
+    // IDENTITY가 1부터 시작하므로, 초기 값인 0L은 무시되며, 엔티티가 저장될 때 데이터베이스가 올바른 자동 증가 값을 할당
     var name: String,
     // 이메일은 중복되지 않아야 하며 수정되지 않아야 합니다.
     @Column(unique = true, updatable = false)

--- a/friends_server/src/main/kotlin/com/friends/security/authentication/AuthenticationCreator.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/authentication/AuthenticationCreator.kt
@@ -1,0 +1,17 @@
+package com.friends.security.authentication
+
+import com.friends.security.jwt.JwtInterface
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+
+@Component
+class AuthenticationCreator(
+    private val jwtInterface: JwtInterface,
+) {
+    fun createByAccessToken(accessToken: String): Authentication {
+        val memberId = jwtInterface.getMemberId(accessToken)
+        val authorities = jwtInterface.getAuthorities(accessToken)
+        return UsernamePasswordAuthenticationToken(memberId, accessToken, authorities)
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/security/filter/JwtFilter.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/filter/JwtFilter.kt
@@ -1,0 +1,36 @@
+package com.friends.security.filter
+
+import com.friends.security.authentication.AuthenticationCreator
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtFilter(
+    private val authenticationCreator: AuthenticationCreator,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        resolveToken(request)?.let {
+            val authentication: Authentication = authenticationCreator.createByAccessToken(it)
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String? {
+        val bearerToken = request.getHeader("Authorization")
+        return if (!bearerToken.isNullOrEmpty() && bearerToken.startsWith("Bearer ")) {
+            bearerToken.substring(7)
+        } else {
+            null
+        }
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/security/jwt/JwtInterface.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/jwt/JwtInterface.kt
@@ -1,7 +1,9 @@
 package com.friends.security.jwt
 
 import org.springframework.security.core.GrantedAuthority
+import org.springframework.stereotype.Component
 
+@Component
 interface JwtInterface {
     fun getMemberId(token: String): Long {
         TODO("Not yet implemented")

--- a/friends_server/src/main/kotlin/com/friends/security/jwt/JwtInterface.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/jwt/JwtInterface.kt
@@ -23,7 +23,6 @@ interface JwtInterface {
     fun createRefreshToken(
         memberId: Long,
         authorities: Collection<GrantedAuthority>,
-        rotateId: String,
     ): String {
         TODO("Not yet implemented")
     }

--- a/friends_server/src/main/kotlin/com/friends/security/securityException/InvalidTokenException.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/securityException/InvalidTokenException.kt
@@ -12,7 +12,7 @@ class InvalidRefreshTokenException() :
 class MissingSocialAccessTokenException() :
     InvalidJwtException(
         ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN,
-        ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN.httpStatus
+        ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN.httpStatus,
     )
 
 class MissingRefreshTokenException() :

--- a/friends_server/src/main/kotlin/com/friends/security/securityException/InvalidTokenException.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/securityException/InvalidTokenException.kt
@@ -1,0 +1,19 @@
+package com.friends.security.securityException
+
+import com.friends.common.exception.ErrorCode
+import org.springframework.http.HttpStatus
+
+open class InvalidJwtException(val errorCode: ErrorCode, val httpStatus: HttpStatus) :
+    RuntimeException(errorCode.errorMessage)
+
+class InvalidRefreshTokenException() :
+    InvalidJwtException(ErrorCode.INVALID_REFRESH_TOKEN, ErrorCode.INVALID_REFRESH_TOKEN.httpStatus)
+
+class MissingSocialAccessTokenException() :
+    InvalidJwtException(
+        ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN,
+        ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN.httpStatus
+    )
+
+class MissingRefreshTokenException() :
+    InvalidJwtException(ErrorCode.MISSING_REFRESH_TOKEN, ErrorCode.MISSING_REFRESH_TOKEN.httpStatus)

--- a/friends_server/src/main/kotlin/com/friends/security/securityException/InvalidTokenException.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/securityException/InvalidTokenException.kt
@@ -1,19 +1,12 @@
 package com.friends.security.securityException
 
 import com.friends.common.exception.ErrorCode
-import org.springframework.http.HttpStatus
 
-open class InvalidJwtException(val errorCode: ErrorCode, val httpStatus: HttpStatus) :
+open class InvalidJwtException(val errorCode: ErrorCode) :
     RuntimeException(errorCode.errorMessage)
 
-class InvalidRefreshTokenException() :
-    InvalidJwtException(ErrorCode.INVALID_REFRESH_TOKEN, ErrorCode.INVALID_REFRESH_TOKEN.httpStatus)
-
 class MissingSocialAccessTokenException() :
-    InvalidJwtException(
-        ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN,
-        ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN.httpStatus,
-    )
+    InvalidJwtException(ErrorCode.MISSING_SOCIAL_ACCESS_TOKEN)
 
 class MissingRefreshTokenException() :
-    InvalidJwtException(ErrorCode.MISSING_REFRESH_TOKEN, ErrorCode.MISSING_REFRESH_TOKEN.httpStatus)
+    InvalidJwtException(ErrorCode.MISSING_REFRESH_TOKEN)

--- a/friends_server/src/main/kotlin/com/friends/security/service/AuthDtos.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/service/AuthDtos.kt
@@ -1,0 +1,16 @@
+package com.friends.security.service
+
+data class LoginRequestDto(
+    val email: String,
+    val password: String,
+)
+
+data class LoginResponseDto(
+    val memberId: Long,
+    val accessToken: String,
+)
+
+data class AtRtDto(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/friends_server/src/main/kotlin/com/friends/security/service/AuthServices.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/service/AuthServices.kt
@@ -1,0 +1,44 @@
+package com.friends.security.service
+
+import com.friends.member.entity.Member
+import com.friends.member.repository.MemberRepository
+import com.friends.security.jwt.JwtInterface
+import com.friends.security.userDetails.CustomUserDetails
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+
+@Service
+class AuthService(
+    private val authenticationManager: AuthenticationManager,
+    private val jwtInterface: JwtInterface,
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder,
+) {
+    fun login(
+        email: String,
+        password: String,
+    ): AtRtDto {
+        val authenticate = authenticationManager.authenticate(UsernamePasswordAuthenticationToken(email, password))
+        val userDetails = authenticate.principal as CustomUserDetails
+        val accessToken = jwtInterface.createAccessToken(userDetails.memberId, userDetails.authorities)
+        val refreshToken = jwtInterface.createRefreshToken(userDetails.memberId, userDetails.authorities)
+        return AtRtDto(accessToken, refreshToken)
+    }
+
+    fun register(
+        emailAuthToken: String,
+        email: String,
+        password: String,
+        name: String,
+    ) {
+        val user =
+            Member.createUser(
+                name = name,
+                email = email,
+                password = passwordEncoder.encode(password),
+            )
+        memberRepository.save(user)
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/security/userDetails/CustomUserDetails.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/userDetails/CustomUserDetails.kt
@@ -9,12 +9,11 @@ class CustomUserDetails(
     private val member: Member,
 ) : UserDetails {
     private val authorities: Collection<GrantedAuthority> =
-        member.authorities.map {
-                authority ->
+        member.authorities.map { authority ->
             SimpleGrantedAuthority(authority.role.name)
         }
 
-    fun getMemberId(): Long = member.id
+    val memberId = member.id
 
     override fun getAuthorities(): Collection<GrantedAuthority> = authorities
 


### PR DESCRIPTION
## 📝 Pull Request 내용
spring security 에서 인증, 인가 설정을 완료하였습니다.
이메일, 패스워드 기반 회원가입, 로그인 서비스를 완성하였습니다.

### 📑 변경 사항
- [ ] 멤버 엔티티의 oauth2Proivder 와 imageUrl 을 nullable 로 변경하였습니다.
- [ ] spring security configuration 을 작성하고 `api/user` 의 prefix 를 갖는 api 는 유저 권한 인가 검사를, `api/admin` prefix 를 갖는 api 는 관리자 권한 인가 검사를 진행하도록 설정하였습니다.
- [ ] jwtFilter 를 만들어서 spring security 에 포함하고 미리 만들어 좋은 jwtFilter 에러 핸들러를 필터에 설정하였습니다.
- [ ] 회원가입, 로그인 서비스를 구현하고 비밀번호의 경우 암호화되어 DB 에 저장될 수 있도록 하였습니다.

### 🔗 관련 이슈
- 관련된 이슈 번호 #10 

### 💬 기타 참고 사항
- 중간에 다른 브런치를 병합하는 바람에 변동된 코드가 매우 많은데, 커밋 중심으로 리뷰해주시면 좀 더 수월하실 것 같습니다.
(다음 부터는 브런치가 데브 브런치 병합되길 기다렸다가 생성해야겠네요.. 하하)