### PR TITLE
Feature/jwt service test

### DIFF
--- a/friends_server/src/test/kotlin/com/friends/jwt/AtRtServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/jwt/AtRtServiceTest.kt
@@ -1,0 +1,138 @@
+package com.friends.jwt
+
+import com.friends.config.AuthProperties
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+class AtRtServiceTest :
+    BehaviorSpec({
+        val jwtService = mockk<JwtService>()
+        val authProperties =
+            AuthProperties(
+                accessTokenExpiration = 3600L,
+                refreshTokenExpiration = 7200L,
+            )
+        val authJwtRepository = mockk<AuthJwtRepository>(relaxed = true)
+        val atRtService = AtRtService(jwtService, authProperties, authJwtRepository)
+
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        given("createAtRt 호출") {
+            val memberId = 123L
+            val authorities = listOf(SimpleGrantedAuthority("ROLE_USER"))
+            val accessToken = "mockAccessToken"
+            val refreshToken = "mockRefreshToken"
+
+            every {
+                jwtService.createToken(
+                    "memberId" to memberId,
+                    "authorities" to authorities.map { it.authority },
+                    expirationSeconds = authProperties.accessTokenExpiration,
+                )
+            } returns accessToken
+
+            every {
+                jwtService.createToken(
+                    "memberId" to memberId,
+                    "authorities" to authorities.map { it.authority },
+                    expirationSeconds = authProperties.refreshTokenExpiration,
+                )
+            } returns refreshToken
+
+            `when`("createAtRt를 호출하면") {
+                val atRtDto = atRtService.createAtRt(memberId, authorities)
+
+                then("AccessToken과 RefreshToken이 생성되어야 한다") {
+                    atRtDto.accessToken shouldBe accessToken
+                    atRtDto.refreshToken shouldBe refreshToken
+                }
+
+                then("AuthJwtRepository에 토큰이 저장되어야 한다") {
+                    verify { authJwtRepository.save(accessToken, refreshToken) }
+                }
+            }
+        }
+
+        given("getMemberId 호출") {
+            val token = "mockToken"
+            val memberId = 123L
+
+            every { jwtService.getClaim(token, "memberId", Long::class.java) } returns memberId
+
+            `when`("getMemberId를 호출하면") {
+                val result = atRtService.getMemberId(token)
+
+                then("올바른 memberId를 반환해야 한다") {
+                    result shouldBe memberId
+                }
+            }
+        }
+
+        given("getAuthorities 호출") {
+            val token = "mockToken"
+            val authorities = listOf("ROLE_USER", "ROLE_ADMIN")
+
+            every { jwtService.getClaim(token, "authorities", List::class.java) } returns authorities
+
+            `when`("getAuthorities를 호출하면") {
+                val result = atRtService.getAuthorities(token)
+
+                then("GrantedAuthority 리스트를 반환해야 한다") {
+                    result shouldBe authorities.map { SimpleGrantedAuthority(it) }
+                }
+            }
+        }
+
+        given("토큰 검증 메서드 호출") {
+            val accessToken = "mockAccessToken"
+            val refreshToken = "mockRefreshToken"
+
+            every { authJwtRepository.getAccessToken(refreshToken) } returns accessToken
+            every { authJwtRepository.getRefreshToken(accessToken) } returns refreshToken
+
+            `when`("validateRefreshToken이 호출되면") {
+                val result = atRtService.validateRefreshToken(refreshToken)
+
+                then("refreshToken이 유효해야 한다") {
+                    result shouldBe true
+                }
+            }
+
+            `when`("validateAccessToken이 호출되면") {
+                val result = atRtService.validateAccessToken(accessToken)
+
+                then("accessToken이 유효해야 한다") {
+                    result shouldBe true
+                }
+            }
+        }
+
+        given("토큰 삭제 메서드 호출") {
+            val accessToken = "mockAccessToken"
+            val refreshToken = "mockRefreshToken"
+
+            every { authJwtRepository.deleteAccessToken(accessToken) } returns true
+            every { authJwtRepository.deleteRefreshToken(refreshToken) } returns true
+
+            `when`("deleteAccessToken이 호출되면") {
+                atRtService.deleteAccessToken(accessToken)
+
+                then("accessToken이 삭제되어야 한다") {
+                    verify { authJwtRepository.deleteAccessToken(accessToken) }
+                }
+            }
+
+            `when`("deleteRefreshToken이 호출되면") {
+                atRtService.deleteRefreshToken(refreshToken)
+
+                then("refreshToken이 삭제되어야 한다") {
+                    verify { authJwtRepository.deleteRefreshToken(refreshToken) }
+                }
+            }
+        }
+    })

--- a/friends_server/src/test/kotlin/com/friends/jwt/AtRtServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/jwt/AtRtServiceTest.kt
@@ -1,6 +1,8 @@
 package com.friends.jwt
 
 import com.friends.config.AuthProperties
+import com.friends.member.MEMBER_ID
+import com.friends.member.makeUserAuthorities
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -23,10 +25,10 @@ class AtRtServiceTest :
         isolationMode = IsolationMode.InstancePerLeaf
 
         given("createAtRt 호출") {
-            val memberId = 123L
-            val authorities = listOf(SimpleGrantedAuthority("ROLE_USER"))
-            val accessToken = "mockAccessToken"
-            val refreshToken = "mockRefreshToken"
+            val memberId = MEMBER_ID
+            val authorities = makeUserAuthorities()
+            val accessToken = VALID_ACCESS_TOKEN
+            val refreshToken = VALID_REFRESH_TOKEN
 
             every {
                 jwtService.createToken(
@@ -74,7 +76,7 @@ class AtRtServiceTest :
         }
 
         given("getAuthorities 호출") {
-            val token = "mockToken"
+            val token = VALID_TOKEN
             val authorities = listOf("ROLE_USER", "ROLE_ADMIN")
 
             every { jwtService.getClaim(token, "authorities", List::class.java) } returns authorities
@@ -89,8 +91,8 @@ class AtRtServiceTest :
         }
 
         given("토큰 검증 메서드 호출") {
-            val accessToken = "mockAccessToken"
-            val refreshToken = "mockRefreshToken"
+            val accessToken = VALID_ACCESS_TOKEN
+            val refreshToken = VALID_REFRESH_TOKEN
 
             every { authJwtRepository.getAccessToken(refreshToken) } returns accessToken
             every { authJwtRepository.getRefreshToken(accessToken) } returns refreshToken
@@ -113,8 +115,8 @@ class AtRtServiceTest :
         }
 
         given("토큰 삭제 메서드 호출") {
-            val accessToken = "mockAccessToken"
-            val refreshToken = "mockRefreshToken"
+            val accessToken = VALID_ACCESS_TOKEN
+            val refreshToken = VALID_REFRESH_TOKEN
 
             every { authJwtRepository.deleteAccessToken(accessToken) } returns true
             every { authJwtRepository.deleteRefreshToken(refreshToken) } returns true

--- a/friends_server/src/test/kotlin/com/friends/jwt/JwtFixture.kt
+++ b/friends_server/src/test/kotlin/com/friends/jwt/JwtFixture.kt
@@ -1,0 +1,8 @@
+package com.friends.jwt
+
+val AUTHORIZATION_HEADER = "Authorization"
+val VALID_TOKEN = "valid.jwt.token"
+val INVALID_TOKEN = "invalid.jwt.token"
+
+val VALID_ACCESS_TOKEN = "valid.access.token"
+val VALID_REFRESH_TOKEN = "valid.refresh.token"

--- a/friends_server/src/test/kotlin/com/friends/jwt/JwtServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/jwt/JwtServiceTest.kt
@@ -1,0 +1,78 @@
+package com.friends.jwt
+
+import com.friends.config.JwtProperties
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import java.util.Date
+import kotlin.math.abs
+
+class JwtServiceTest :
+    BehaviorSpec({
+        val jwtSecret = "sample-secret-key-1234123412341234123412341234123412341234"
+        val jwtProperties = JwtProperties(secretKey = jwtSecret)
+        val jwtService = JwtService(jwtProperties)
+
+        given("유효한 jwtService 가 주어졌을 때") {
+            val claims = mapOf("number" to "12345", "array" to listOf(1, 2, 3))
+            val expirationSeconds = 3600L
+
+            `when`("토큰이 적잘한 클레임과 만료 시간을 가지고 생성될 때") {
+                val token =
+                    jwtService.createToken(
+                        "number" to claims["number"]!!,
+                        "array" to claims["array"]!!,
+                        expirationSeconds = expirationSeconds,
+                    )
+
+                then("생성된 토큰은 비어있지 않아야 한다.") {
+                    token.shouldNotBeEmpty()
+                }
+
+                then("토큰은 주어진 클레임을 가지고 있어야 한다.") {
+                    val number = jwtService.getClaim(token, "number", String::class.java) as String
+                    val array = jwtService.getClaim(token, "array", List::class.java) as List<String>
+
+                    number shouldBe claims["number"]
+                    array shouldBe claims["array"]
+                }
+
+                then("토큰은 주어진 만료 시간을 가지고 있어야 한다.") {
+                    val expiration = jwtService.getExpiration(token)
+                    val expectedExpiration = Date(System.currentTimeMillis() + expirationSeconds * 1000)
+
+                    abs(expiration.time - expectedExpiration.time) shouldBeLessThan 2000
+                }
+            }
+
+            `when`("적절한 유효성 검사가 수행될 때") {
+                val token =
+                    jwtService.createToken(
+                        "number" to claims["number"]!!,
+                        "array" to claims["array"]!!,
+                        expirationSeconds = expirationSeconds,
+                    )
+
+                then("유효한 토큰에 대해 검사가 성공해야 한다.") {
+                    jwtService.validate(token) shouldBe true
+                }
+
+                then("유효하지 않은 토큰에 대해 검사가 실패해야 한다.") {
+                    jwtService.validate("invalid.token.string") shouldBe false
+                }
+            }
+            `when`("만료된 토큰이 주어졌을 때") {
+                val expiredToken =
+                    jwtService.createToken(
+                        "number" to claims["number"]!!,
+                        "array" to claims["array"]!!,
+                        expirationSeconds = -1,
+                    )
+
+                then("만료된 토큰에 대해 검사가 실패해야 한다.") {
+                    jwtService.validate(expiredToken) shouldBe false
+                }
+            }
+        }
+    })

--- a/friends_server/src/test/kotlin/com/friends/jwt/JwtServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/jwt/JwtServiceTest.kt
@@ -1,6 +1,7 @@
 package com.friends.jwt
 
 import com.friends.config.JwtProperties
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
@@ -13,6 +14,8 @@ class JwtServiceTest :
         val jwtSecret = "sample-secret-key-1234123412341234123412341234123412341234"
         val jwtProperties = JwtProperties(secretKey = jwtSecret)
         val jwtService = JwtService(jwtProperties)
+
+        isolationMode = IsolationMode.InstancePerLeaf
 
         given("유효한 jwtService 가 주어졌을 때") {
             val claims = mapOf("number" to "12345", "array" to listOf(1, 2, 3))

--- a/friends_server/src/test/kotlin/com/friends/member/MemberFixture.kt
+++ b/friends_server/src/test/kotlin/com/friends/member/MemberFixture.kt
@@ -1,0 +1,17 @@
+package com.friends.member
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+val MEMBER_ID = 123L
+
+fun makeUserAuthorities(): Collection<GrantedAuthority> =
+    listOf(
+        SimpleGrantedAuthority("ROLE_USER"),
+    )
+
+fun makeAdminAuthorities(): Collection<GrantedAuthority> =
+    listOf(
+        SimpleGrantedAuthority("ROLE_USER"),
+        SimpleGrantedAuthority("ROLE_ADMIN"),
+    )

--- a/friends_server/src/test/kotlin/com/friends/security/filter/JwtFilterTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/security/filter/JwtFilterTest.kt
@@ -1,0 +1,112 @@
+package com.friends.security.filter
+
+import com.friends.security.authentication.AuthenticationCreator
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.FilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+
+class JwtFilterTest :
+    BehaviorSpec({
+        val authenticationCreator = mockk<AuthenticationCreator>()
+        val jwtFilter = JwtFilter(authenticationCreator)
+
+        /**
+         * 테스트 간에 상태가 공유 되지 않도록 합니다.
+         * 각 테스트가 독립적으로 실행됩니다.
+         * given, when 이 then 이 실행될 때마다 새롭게 실행됩니다.
+         */
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        /**
+         * Type이 Test인 테스트(여기서는 then) 이 끝난 뒤 실행됩니다.
+         * SecurityContextHolder 는 스레드 로컬 변수를 사용하기 때문에, 테스트가 끝난 뒤에는 반드시 클리어해주어야 다른 테스트에 영향을 주지 않습니다.
+         */
+        afterEach {
+            SecurityContextHolder.clearContext()
+        }
+
+        given("HTTP 요청에 유효한 JWT가 있는 경우") {
+            val token = "valid.jwt.token"
+            val authentication = mockk<Authentication>()
+            val request =
+                MockHttpServletRequest().apply {
+                    addHeader("Authorization", "Bearer $token")
+                }
+            val response = MockHttpServletResponse()
+            val filterChain = mockk<FilterChain>(relaxed = true)
+
+            every { authenticationCreator.createByAccessToken(token) } returns authentication
+
+            `when`("JwtFilter가 실행될 때") {
+                jwtFilter.doFilter(request, response, filterChain)
+                println(testCase.name.testName)
+
+                then("AuthenticationCreator가 호출되어야 한다") {
+                    verify { authenticationCreator.createByAccessToken(token) }
+                }
+
+//                then("SecurityContextHolder에 Authentication이 설정되어야 한다") {
+//                    SecurityContextHolder.getContext().authentication shouldBe authentication
+//                }
+
+                then("필터 체인이 계속 실행되어야 한다") {
+                    verify { filterChain.doFilter(request, response) }
+                }
+            }
+        }
+
+        given("HTTP 요청에 Authorization 헤더가 없는 경우") {
+            val request = MockHttpServletRequest()
+            val response = MockHttpServletResponse()
+            val filterChain = mockk<FilterChain>(relaxed = true)
+
+            `when`("JwtFilter가 실행될 때") {
+                jwtFilter.doFilter(request, response, filterChain)
+
+                then("AuthenticationCreator는 호출되지 않아야 한다") {
+                    verify(exactly = 0) { authenticationCreator.createByAccessToken(any()) }
+                }
+
+                then("SecurityContextHolder는 변경되지 않아야 한다") {
+                    SecurityContextHolder.getContext().authentication shouldBe null
+                }
+
+                then("필터 체인이 계속 실행되어야 한다") {
+                    verify { filterChain.doFilter(request, response) }
+                }
+            }
+        }
+
+        given("HTTP 요청에 잘못된 Authorization 헤더가 있는 경우") {
+            val request =
+                MockHttpServletRequest().apply {
+                    addHeader("Authorization", "InvalidHeader")
+                }
+            val response = MockHttpServletResponse()
+            val filterChain = mockk<FilterChain>(relaxed = true)
+
+            `when`("JwtFilter가 실행될 때") {
+                jwtFilter.doFilter(request, response, filterChain)
+
+                then("AuthenticationCreator는 호출되지 않아야 한다") {
+                    verify(exactly = 0) { authenticationCreator.createByAccessToken(any()) }
+                }
+
+                then("SecurityContextHolder는 변경되지 않아야 한다") {
+                    SecurityContextHolder.getContext().authentication shouldBe null
+                }
+
+                then("필터 체인이 계속 실행되어야 한다") {
+                    verify { filterChain.doFilter(request, response) }
+                }
+            }
+        }
+    })

--- a/friends_server/src/test/kotlin/com/friends/security/filter/JwtFilterTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/security/filter/JwtFilterTest.kt
@@ -1,5 +1,8 @@
 package com.friends.security.filter
 
+import com.friends.jwt.AUTHORIZATION_HEADER
+import com.friends.jwt.INVALID_TOKEN
+import com.friends.jwt.VALID_TOKEN
 import com.friends.security.authentication.AuthenticationCreator
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
@@ -18,11 +21,6 @@ class JwtFilterTest :
         val authenticationCreator = mockk<AuthenticationCreator>()
         val jwtFilter = JwtFilter(authenticationCreator)
 
-        /**
-         * 테스트 간에 상태가 공유 되지 않도록 합니다.
-         * 각 테스트가 독립적으로 실행됩니다.
-         * given, when 이 then 이 실행될 때마다 새롭게 실행됩니다.
-         */
         isolationMode = IsolationMode.InstancePerLeaf
 
         /**
@@ -34,7 +32,7 @@ class JwtFilterTest :
         }
 
         given("HTTP 요청에 유효한 JWT가 있는 경우") {
-            val token = "valid.jwt.token"
+            val token = VALID_TOKEN
             val authentication = mockk<Authentication>()
             val request =
                 MockHttpServletRequest().apply {
@@ -47,15 +45,14 @@ class JwtFilterTest :
 
             `when`("JwtFilter가 실행될 때") {
                 jwtFilter.doFilter(request, response, filterChain)
-                println(testCase.name.testName)
 
                 then("AuthenticationCreator가 호출되어야 한다") {
                     verify { authenticationCreator.createByAccessToken(token) }
                 }
 
-//                then("SecurityContextHolder에 Authentication이 설정되어야 한다") {
-//                    SecurityContextHolder.getContext().authentication shouldBe authentication
-//                }
+                then("SecurityContextHolder에 Authentication이 설정되어야 한다") {
+                    SecurityContextHolder.getContext().authentication shouldBe authentication
+                }
 
                 then("필터 체인이 계속 실행되어야 한다") {
                     verify { filterChain.doFilter(request, response) }
@@ -88,7 +85,7 @@ class JwtFilterTest :
         given("HTTP 요청에 잘못된 Authorization 헤더가 있는 경우") {
             val request =
                 MockHttpServletRequest().apply {
-                    addHeader("Authorization", "InvalidHeader")
+                    addHeader(AUTHORIZATION_HEADER, INVALID_TOKEN)
                 }
             val response = MockHttpServletResponse()
             val filterChain = mockk<FilterChain>(relaxed = true)


### PR DESCRIPTION
## 📝 Pull Request 내용
jwtFilterTest, jwtServiceTest, AtRtServiceTest 에 대한 테스트 코드를 작성하였습니다

### 📑 변경 사항
- kotest, mockk 라이브러리를 활용하였습니다.
- kotest 의 BehaviorSpec 의 given-when-then 패턴을 사용해 테스트 코드를 작성하였습니다.
- `isolationMode = IsolationMode.InstancePerLeaf` 를 설정하였습니다.

### 🔗 관련 이슈
- #33 

### 💬 기타 참고 사항
`isolationMode = IsolationMode.SingleInstance` 가 default 값인데, BehaviorSpec 안에서 생성된 인스턴스를 하나만 사용하는 것이라고 합니다.

BehaviorSpec 에서 여러 단위 테스트를 진행하는데 하나의 인스턴스가 공유되면 각 단위 테스트가 서로 영향을 미칠 수 있다고 생각했어요!
그래서 `isolationMode = IsolationMode.InstancePerLeaf` 를 설정하였습니다.
위의 옵션은 가장 하위 단위 테스트(BehaviorSpec 에서는 then) 가 실행될 때마다 인스턴스를 새롭게 만드는 옵션이라고 합니다.

테스트를 진행할 때 각 단위 테스트가 독립적으로 실행되는게 좋은 패턴이라고 생각해 Spec 을 사용한다면 `InstancePerLeaf` 를 설정하는게 좋을 것 같은데 어떻게 생각하시는지 궁금합니다~~

참고)
Lifecycle Hook 인 BeforeEach 등을 사용하여 인스턴스를 초기화하는 것도 좋다고 생각해요!
다만 어떤 내용이 변경되었는지 신경쓰면서 테스트 코드를 작성해 하나의 인스턴스에서 해당 부분만 초기화하는 건 조금 불편할수도 있다고 생각했어요.
예상치 못한 부분이 변경될 수도 있고요! 그래서 인스턴스를 새롭게 만드는 방법이 끌렸습니다..ㅎㅎ

### 래퍼런스
[스프링에서 코틀린 스타일 테스트 코드 작성하기 | 우아한형제들 기술블로그](https://techblog.woowahan.com/5825/)

[Isolation Modes | Kotest](https://kotest.io/docs/framework/isolation-mode.html)

[Kotest의 Lifecycle Hook, IsolationMode](https://velog.io/@glencode/Kotest%EC%9D%98-Lifecycle-Hook-IsolationMode)