### PR TITLE
Feature/email verification

### DIFF
--- a/friends_server/build.gradle.kts
+++ b/friends_server/build.gradle.kts
@@ -50,6 +50,11 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-impl:0.12.6")
     implementation("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
+    // email
+    implementation("org.springframework.boot:spring-boot-starter-mail")
+    // thyemleaf
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+
     // configuration property
     implementation("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/friends_server/src/main/kotlin/com/friends/FriendsServerApplication.kt
+++ b/friends_server/src/main/kotlin/com/friends/FriendsServerApplication.kt
@@ -1,6 +1,7 @@
 package com.friends
 
 import com.friends.config.AuthProperties
+import com.friends.config.EmailProperties
 import com.friends.config.JwtProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -11,7 +12,7 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 @SpringBootApplication
 @EnableMongoRepositories
 @EnableMongoAuditing
-@EnableConfigurationProperties(JwtProperties::class, AuthProperties::class)
+@EnableConfigurationProperties(JwtProperties::class, AuthProperties::class, EmailProperties::class)
 class FriendsServerApplication
 
 fun main(args: Array<String>) {

--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
@@ -2,7 +2,11 @@ package com.friends.common.exception
 
 import org.springframework.http.HttpStatus
 
-enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage: String) {
+enum class ErrorCode(
+    val httpStatus: HttpStatus,
+    val code: Int,
+    val errorMessage: String,
+) {
     // global error
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, -10000, "적절하지 않은 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, -10001, "서버 내부 오류입니다."),
@@ -14,4 +18,9 @@ enum class ErrorCode(val httpStatus: HttpStatus, val code: Int, val errorMessage
 
     // Member API error 12000대
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, -12001, "존재하지 않는 회원입니다."),
+
+    // Email API error 13000대
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, -13001, "유효하지 않은 이메일입니다."),
+    INVALID_EMAIL_VERIFY_CODE(HttpStatus.UNAUTHORIZED, -13002, "유효하지 않은 이메일 인증 코드입니다."),
+    SMTP_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, -13003, "이메일 서버와의 연결에 실패했습니다."),
 }

--- a/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.friends.common.exception
 
+import com.friends.email.EmailException
 import com.friends.security.securityException.InvalidJwtException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -15,7 +16,16 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(InvalidJwtException::class)
     fun handleInvalidJwtException(ex: InvalidJwtException): ResponseEntity<Any> {
         log.error("Invalid JWT", ex)
-        return ResponseEntity.status(ex.errorCode.httpStatus)
+        return ResponseEntity
+            .status(ex.errorCode.httpStatus)
+            .body(ErrorResponse.of(ex.errorCode, ex.message))
+    }
+
+    @ExceptionHandler(EmailException::class)
+    fun handleEmailException(ex: EmailException): ResponseEntity<Any> {
+        log.error("Email Exception", ex)
+        return ResponseEntity
+            .status(ex.errorCode.httpStatus)
             .body(ErrorResponse.of(ex.errorCode, ex.message))
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/config/ApplicationProperties.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/ApplicationProperties.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 class AuthProperties(
     val accessTokenExpiration: Long,
     val refreshTokenExpiration: Long,
+    val emailCodeExpiration: Long,
 )
 
 @ConfigurationProperties(prefix = "jwt")

--- a/friends_server/src/main/kotlin/com/friends/config/ApplicationProperties.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/ApplicationProperties.kt
@@ -7,6 +7,7 @@ class AuthProperties(
     val accessTokenExpiration: Long,
     val refreshTokenExpiration: Long,
     val emailCodeExpiration: Long,
+    val emailJwtExpiration: Long,
 )
 
 @ConfigurationProperties(prefix = "jwt")

--- a/friends_server/src/main/kotlin/com/friends/config/ApplicationProperties.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/ApplicationProperties.kt
@@ -12,3 +12,15 @@ class AuthProperties(
 class JwtProperties(
     val secretKey: String,
 )
+
+@ConfigurationProperties(prefix = "spring.mail")
+class EmailProperties(
+    val host: String,
+    val port: Int,
+    val username: String,
+    val password: String,
+    val auth: Boolean,
+    val starttls: Boolean,
+    val debug: Boolean,
+    val connectiontimeout: Int,
+)

--- a/friends_server/src/main/kotlin/com/friends/config/EmailConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/EmailConfig.kt
@@ -1,0 +1,30 @@
+package com.friends.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.JavaMailSenderImpl
+import java.util.Properties
+
+@Configuration
+class EmailConfig(
+    private val emailProperties: EmailProperties,
+) {
+    @Bean
+    fun getJavaMailSender(): JavaMailSender {
+        val mailSender = JavaMailSenderImpl()
+        mailSender.host = emailProperties.host
+        mailSender.port = emailProperties.port
+
+        mailSender.username = emailProperties.username
+        mailSender.password = emailProperties.password
+
+        val props: Properties = mailSender.javaMailProperties
+        props["mail.smtp.auth"] = emailProperties.auth
+        props["mail.smtp.starttls.enable"] = emailProperties.starttls
+        props["mail.debug"] = emailProperties.debug
+        props["mail.smtp.connectiontimeout"] = emailProperties.connectiontimeout
+
+        return mailSender
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
@@ -42,12 +42,14 @@ class SpringSecurityConfig(
 
         http.authorizeHttpRequests {
             it
+                .requestMatchers("/api/auth/**", "/api/global/**")
+                .permitAll()
                 .requestMatchers("/api/user/**")
                 .hasAuthority(Role.ROLE_USER.name)
                 .requestMatchers("/api/admin/**")
                 .hasAuthority(Role.ROLE_ADMIN.name)
                 .anyRequest()
-                .permitAll()
+                .authenticated()
         }
 
         return http.build()

--- a/friends_server/src/main/kotlin/com/friends/email/EmailDtos.kt
+++ b/friends_server/src/main/kotlin/com/friends/email/EmailDtos.kt
@@ -1,0 +1,15 @@
+package com.friends.email
+
+data class EmailDto(
+    // 이메일 유효성 검사 진행 미구현
+    val email: String,
+)
+
+data class EmailVerifyRequestDto(
+    val email: String,
+    val code: String,
+)
+
+data class EmailVerifyResponseDto(
+    val emailAuthToken: String,
+)

--- a/friends_server/src/main/kotlin/com/friends/email/EmailExceptions.kt
+++ b/friends_server/src/main/kotlin/com/friends/email/EmailExceptions.kt
@@ -3,7 +3,9 @@ package com.friends.email
 import com.friends.common.exception.ErrorCode
 
 abstract class EmailException(
-    private val errorCode: ErrorCode,
+    val errorCode: ErrorCode,
 ) : RuntimeException(errorCode.errorMessage)
+
+class EmailVerifyFailedException : EmailException(ErrorCode.INVALID_EMAIL_VERIFY_CODE)
 
 class EmailSendFailedException : EmailException(ErrorCode.SMTP_CONNECTION_FAILED)

--- a/friends_server/src/main/kotlin/com/friends/email/EmailExceptions.kt
+++ b/friends_server/src/main/kotlin/com/friends/email/EmailExceptions.kt
@@ -1,0 +1,9 @@
+package com.friends.email
+
+import com.friends.common.exception.ErrorCode
+
+abstract class EmailException(
+    private val errorCode: ErrorCode,
+) : RuntimeException(errorCode.errorMessage)
+
+class EmailSendFailedException : EmailException(ErrorCode.SMTP_CONNECTION_FAILED)

--- a/friends_server/src/main/kotlin/com/friends/email/EmailService.kt
+++ b/friends_server/src/main/kotlin/com/friends/email/EmailService.kt
@@ -1,0 +1,25 @@
+package com.friends.email
+
+import jakarta.mail.Message
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.stereotype.Service
+
+@Service
+class EmailService(
+    private val javaMailSender: JavaMailSender,
+) {
+    fun sendHtml(
+        to: String,
+        subject: String,
+        html: String,
+    ) {
+        val message = javaMailSender.createMimeMessage()
+        message.subject = subject
+        message.setText(html, "utf-8", "html")
+        message.setRecipients(
+            Message.RecipientType.TO,
+            to,
+        )
+        javaMailSender.send(message)
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/email/EmailService.kt
+++ b/friends_server/src/main/kotlin/com/friends/email/EmailService.kt
@@ -1,6 +1,7 @@
 package com.friends.email
 
 import jakarta.mail.Message
+import org.slf4j.LoggerFactory
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Service
 
@@ -8,6 +9,8 @@ import org.springframework.stereotype.Service
 class EmailService(
     private val javaMailSender: JavaMailSender,
 ) {
+    private val log = LoggerFactory.getLogger(this.javaClass)
+
     fun sendHtml(
         to: String,
         subject: String,
@@ -23,6 +26,7 @@ class EmailService(
             )
             javaMailSender.send(message)
         } catch (e: Exception) {
+            log.error("Failed to send email", e)
             throw EmailSendFailedException()
         }
     }

--- a/friends_server/src/main/kotlin/com/friends/email/EmailService.kt
+++ b/friends_server/src/main/kotlin/com/friends/email/EmailService.kt
@@ -13,13 +13,17 @@ class EmailService(
         subject: String,
         html: String,
     ) {
-        val message = javaMailSender.createMimeMessage()
-        message.subject = subject
-        message.setText(html, "utf-8", "html")
-        message.setRecipients(
-            Message.RecipientType.TO,
-            to,
-        )
-        javaMailSender.send(message)
+        try {
+            val message = javaMailSender.createMimeMessage()
+            message.subject = subject
+            message.setText(html, "utf-8", "html")
+            message.setRecipients(
+                Message.RecipientType.TO,
+                to,
+            )
+            javaMailSender.send(message)
+        } catch (e: Exception) {
+            throw EmailSendFailedException()
+        }
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/email/EmailService.kt
+++ b/friends_server/src/main/kotlin/com/friends/email/EmailService.kt
@@ -1,7 +1,6 @@
 package com.friends.email
 
 import jakarta.mail.Message
-import org.slf4j.LoggerFactory
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Service
 
@@ -9,8 +8,6 @@ import org.springframework.stereotype.Service
 class EmailService(
     private val javaMailSender: JavaMailSender,
 ) {
-    private val log = LoggerFactory.getLogger(this.javaClass)
-
     fun sendHtml(
         to: String,
         subject: String,
@@ -26,7 +23,6 @@ class EmailService(
             )
             javaMailSender.send(message)
         } catch (e: Exception) {
-            log.error("Failed to send email", e)
             throw EmailSendFailedException()
         }
     }

--- a/friends_server/src/main/kotlin/com/friends/email/EmailVerifyController.kt
+++ b/friends_server/src/main/kotlin/com/friends/email/EmailVerifyController.kt
@@ -1,0 +1,29 @@
+package com.friends.email
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/auth")
+class EmailVerifyController(
+    private val emailVerifyService: EmailVerifyService,
+) {
+    @PostMapping("/send-verification-code")
+    fun sendVerifyEmail(
+        @RequestBody emailDto: EmailDto,
+    ): ResponseEntity<String> {
+        emailVerifyService.sendVerifyEmail(emailDto.email)
+        return ResponseEntity.ok("이메일로 인증 코드를 전송했습니다.")
+    }
+
+    @PostMapping("/verify-email")
+    fun verifyEmail(
+        @RequestBody emailVerifyDto: EmailVerifyRequestDto,
+    ): ResponseEntity<EmailVerifyResponseDto> {
+        val token = emailVerifyService.verifyEmail(emailVerifyDto.email, emailVerifyDto.code)
+        return ResponseEntity.ok(EmailVerifyResponseDto(token))
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/email/EmailVerifyService.kt
+++ b/friends_server/src/main/kotlin/com/friends/email/EmailVerifyService.kt
@@ -1,0 +1,53 @@
+package com.friends.email
+
+import com.friends.config.AuthProperties
+import com.friends.jwt.EmailCodeRepository
+import com.friends.jwt.JwtService
+import org.springframework.stereotype.Service
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.Context
+
+const val EMAIL_VERIFY_TEMPLATE_PATH = "email-verify-template"
+const val EMAIL_VERIFY_SUBJECT = "[Friends] 이메일 인증 코드를 확인해주세요"
+
+@Service
+class EmailVerifyService(
+    private val emailService: EmailService,
+    private val emailCodeRepository: EmailCodeRepository,
+    private val templateEngine: TemplateEngine,
+    private val authProperties: AuthProperties,
+    private val jwtService: JwtService,
+) {
+    fun sendVerifyEmail(to: String) {
+        val code = createVerifyCode()
+        emailCodeRepository.save(to, code)
+        val html = createEmailHtml(code)
+        emailService.sendHtml(to, EMAIL_VERIFY_SUBJECT, html)
+    }
+
+    fun verifyEmail(
+        email: String,
+        code: String,
+    ): String {
+        if (!verifyCode(email, code)) {
+            throw EmailVerifyFailedException()
+        }
+        return jwtService.createToken("email" to email, expirationSeconds = authProperties.emailJwtExpiration)
+    }
+
+    private fun verifyCode(
+        email: String,
+        code: String,
+    ): Boolean {
+        val savedCode = emailCodeRepository.getCode(email) ?: return false
+        return savedCode == code
+    }
+
+    private fun createEmailHtml(code: String): String {
+        val context = Context()
+        context.setVariable("code", code)
+        return templateEngine.process(EMAIL_VERIFY_TEMPLATE_PATH, context)
+    }
+
+    private fun createVerifyCode(): String = (100000..999999).random().toString()
+}

--- a/friends_server/src/main/kotlin/com/friends/jwt/EmailCodeRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/jwt/EmailCodeRepository.kt
@@ -1,0 +1,23 @@
+package com.friends.jwt
+
+import com.friends.config.AuthProperties
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+import java.util.concurrent.TimeUnit
+
+@Repository
+class EmailCodeRepository(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val authProperties: AuthProperties,
+) {
+    fun save(
+        email: String,
+        code: String,
+    ) {
+        redisTemplate.opsForValue().set(getCodeKey(email), code, authProperties.emailCodeExpiration, TimeUnit.SECONDS)
+    }
+
+    private fun getCodeKey(email: String) = "emailCode:$email"
+
+    fun getCode(email: String): String? = redisTemplate.opsForValue().get(getCodeKey(email))
+}

--- a/friends_server/src/main/resources/application.yml
+++ b/friends_server/src/main/resources/application.yml
@@ -34,6 +34,15 @@ spring:
       host: localhost
       username: myuser
       password: mypassword
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: friends.dev001
+    password: bmiwugrpcietbyqp
+    auth: true
+    starttls: true
+    debug: true
+    connectiontimeout: 5000
 logging:
   pattern:
     console: "[%d{yyyy-MM-dd HH:mm:ss}] [%highlight(%-5level)] %cyan(%logger.%method:line%line) - %msg%n"

--- a/friends_server/src/main/resources/application.yml
+++ b/friends_server/src/main/resources/application.yml
@@ -59,3 +59,4 @@ auth :
   access-token-expiration: 43200 # 12 hours
   refresh-token-expiration: 604800 # 1 week
   email-code-expiration: 180 #3min
+  email-jwt-expiration: 300 #5min

--- a/friends_server/src/main/resources/application.yml
+++ b/friends_server/src/main/resources/application.yml
@@ -58,3 +58,4 @@ jwt :
 auth :
   access-token-expiration: 43200 # 12 hours
   refresh-token-expiration: 604800 # 1 week
+  email-code-expiration: 180 #3min

--- a/friends_server/src/main/resources/templates/email-verify-template.html
+++ b/friends_server/src/main/resources/templates/email-verify-template.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body style="font-family: 'Noto Sans KR', Arial, sans-serif; line-height: 1.8; background-color: #f7f9fc; margin: 0; padding: 0;">
+<div style="max-width: 600px; margin: 30px auto; background: #ffffff; border-radius: 10px; padding: 20px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);">
+    <div style="text-align: center; padding: 20px 0; background: #6c63ff; color: #ffffff; border-radius: 10px 10px 0 0;">
+        <h1 style="font-size: 26px; margin: 0;">Friends</h1>
+    </div>
+    <div style="padding: 20px; text-align: center;">
+        <p style="font-size: 18px; margin-bottom: 20px;">안녕하세요! Friends 서비스를 이용해 주셔서 감사합니다.</p>
+        <p>아래의 인증 코드를 입력하여 이메일 인증을 완료하세요:</p>
+        <div style="font-size: 40px; font-weight: bold; color: #6c63ff; margin: 20px 0; letter-spacing: 6px;" th:text="${code}"></div>
+        <p style="font-size: 14px; color: #555555; margin-top: 10px;">이 인증 코드는 3분 동안만 유효합니다.</p>
+    </div>
+    <div style="font-size: 12px; color: #888888; margin-top: 20px; text-align: center; line-height: 1.5;">
+        <p>이메일을 보낸 사람: Friends 팀</p>
+        <p>만약 요청하지 않았다면, 이 이메일을 무시하셔도 됩니다.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/friends_server/src/test/kotlin/com/friends/jwt/AtRtServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/jwt/AtRtServiceTest.kt
@@ -18,6 +18,8 @@ class AtRtServiceTest :
             AuthProperties(
                 accessTokenExpiration = 3600L,
                 refreshTokenExpiration = 7200L,
+                0,
+                0,
             )
         val authJwtRepository = mockk<AuthJwtRepository>(relaxed = true)
         val atRtService = AtRtService(jwtService, authProperties, authJwtRepository)


### PR DESCRIPTION
## 📝 Pull Request 내용
이메일에 보안 코드를 보내 이메일은 인증하는 서비스를 구현하였습니다.

### 📑 변경 사항
- [ ] spring-mail, thymeleaf 라이브러리를 활용하여 이메일을 전송하는 서비스를 구현하였습니다.
- [ ] 랜덤한 보안코드를 이메일로 전송하고 보안코드는 redis 에 3분의 제한시간을 걸어 저장하였습니다.
- [ ] 사용자 이메일과 보안코드가 일치하면 이메일이 인증되었다는 것을 보장하는 jwt 를 반환하였습니다.
- [ ] API 명세서 중 `/api/auth/send-verification-code` 와 `/api/auth/verify-email` 을 구현하였습니다.
- [ ] Spring Security 인가 범위를 팀 회의했던 내용을 토대로 수정하였습니다.
  - `api/auth`, `api/global` -> 모두 접근 가능
  - `api/user` -> 유저, 관리자만 접근 가능
  - `api/admin` -> 관리자만 접근 가능

### 🔗 관련 이슈
- close #25 

### 💬 기타 참고 사항
- 메일을 전송하는 계정은 테스트용으로 따로 만들었습니다.
개발하는 과정에서 비밀번호도 공유하는 것이 편할 것 같아 같이 올렸습니다. 
(테스트 계정이고 비밀번호는 언제든지 비활성화할 수 있으므로 문제가 생기면 조치하겠습니다.)

- 이메일 전송 html 폼은 chatGPT 를 사용해서 꾸며봤는데, 프론트앤드 분들에게 디자인을 부탁해볼까요? 🤔 
![image](https://github.com/user-attachments/assets/3eb30c24-3783-400e-90ed-d0290eca9e0a)
- controller 단에서 사용하는 requestDTO 에서 이메일을 받는데, 이메일 유효성 검사를 추가할까요? 

