### PR TITLE
Feature/oauth2

### DIFF
--- a/friends_server/.gitignore
+++ b/friends_server/.gitignore
@@ -38,3 +38,5 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+application.yml

--- a/friends_server/build.gradle.kts
+++ b/friends_server/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-impl:0.12.6")
     implementation("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
+    // web client
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+
     // email
     implementation("org.springframework.boot:spring-boot-starter-mail")
     // thyemleaf

--- a/friends_server/src/main/kotlin/com/friends/FriendsServerApplication.kt
+++ b/friends_server/src/main/kotlin/com/friends/FriendsServerApplication.kt
@@ -3,6 +3,7 @@ package com.friends
 import com.friends.config.AuthProperties
 import com.friends.config.EmailProperties
 import com.friends.config.JwtProperties
+import com.friends.config.OAuth2Properties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
@@ -12,7 +13,7 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 @SpringBootApplication
 @EnableMongoRepositories
 @EnableMongoAuditing
-@EnableConfigurationProperties(JwtProperties::class, AuthProperties::class, EmailProperties::class)
+@EnableConfigurationProperties(JwtProperties::class, AuthProperties::class, EmailProperties::class, OAuth2Properties::class)
 class FriendsServerApplication
 
 fun main(args: Array<String>) {

--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
@@ -23,4 +23,9 @@ enum class ErrorCode(
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, -13001, "유효하지 않은 이메일입니다."),
     INVALID_EMAIL_VERIFY_CODE(HttpStatus.UNAUTHORIZED, -13002, "유효하지 않은 이메일 인증 코드입니다."),
     SMTP_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, -13003, "이메일 서버와의 연결에 실패했습니다."),
+
+    // OAuth2 API error 14000대
+    OAUTH2_ACCESS_TOKEN_FETCH_FAILED(HttpStatus.UNAUTHORIZED, -14001, "OAuth2 Access Token 획득에 실패했습니다."),
+    OAUTH2_USER_INFO_FETCH_FAILED(HttpStatus.UNAUTHORIZED, -14002, "OAuth2 User 정보 획득에 실패했습니다."),
+    OAUTH2_NULL_RESPONSE(HttpStatus.BAD_GATEWAY, -14003, "OAuth2 API로부터 응답이 없습니다."),
 }

--- a/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.friends.common.exception
 
 import com.friends.email.EmailException
+import com.friends.oauth2.OAuth2Exception
 import com.friends.security.securityException.InvalidJwtException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -24,6 +25,14 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(EmailException::class)
     fun handleEmailException(ex: EmailException): ResponseEntity<Any> {
         log.error("Email Exception", ex)
+        return ResponseEntity
+            .status(ex.errorCode.httpStatus)
+            .body(ErrorResponse.of(ex.errorCode, ex.message))
+    }
+
+    @ExceptionHandler(OAuth2Exception::class)
+    fun handleOAuth2Exception(ex: OAuth2Exception): ResponseEntity<Any> {
+        log.error("OAuth2 Exception", ex)
         return ResponseEntity
             .status(ex.errorCode.httpStatus)
             .body(ErrorResponse.of(ex.errorCode, ex.message))

--- a/friends_server/src/main/kotlin/com/friends/config/ApplicationProperties.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/ApplicationProperties.kt
@@ -1,5 +1,6 @@
 package com.friends.config
 
+import com.friends.member.entity.OAuth2Provider
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "auth")
@@ -26,3 +27,23 @@ class EmailProperties(
     val debug: Boolean,
     val connectiontimeout: Int,
 )
+
+@ConfigurationProperties(prefix = "oauth2")
+class OAuth2Properties(
+    val naver: Provider,
+    val google: Provider,
+) {
+    fun get(oAuth2Provider: OAuth2Provider): Provider =
+        when (oAuth2Provider) {
+            OAuth2Provider.NAVER -> naver
+            OAuth2Provider.GOOGLE -> google
+        }
+
+    data class Provider(
+        val clientId: String,
+        val clientSecret: String,
+        val redirectUrl: String,
+        val tokenUrl: String,
+        val userInfoUrl: String,
+    )
+}

--- a/friends_server/src/main/kotlin/com/friends/member/entity/MemberEnums.kt
+++ b/friends_server/src/main/kotlin/com/friends/member/entity/MemberEnums.kt
@@ -1,8 +1,18 @@
 package com.friends.member.entity
 
-enum class OAuth2Provider {
-    GOOGLE,
-    NAVER,
+import com.friends.oauth2.GoogleUserProfileExtractor
+import com.friends.oauth2.NaverUserProfileExtractor
+import com.friends.oauth2.UserProfileDto
+import com.friends.oauth2.UserProfileExtractor
+
+enum class OAuth2Provider(
+    val extractor: UserProfileExtractor,
+) {
+    GOOGLE(GoogleUserProfileExtractor()),
+    NAVER(NaverUserProfileExtractor()),
+    ;
+
+    fun extract(attributes: Map<String, Any>): UserProfileDto = extractor.extract(attributes)
 }
 
 enum class Role {

--- a/friends_server/src/main/kotlin/com/friends/member/entity/MemberEnums.kt
+++ b/friends_server/src/main/kotlin/com/friends/member/entity/MemberEnums.kt
@@ -6,7 +6,7 @@ import com.friends.oauth2.UserProfileDto
 import com.friends.oauth2.UserProfileExtractor
 
 enum class OAuth2Provider(
-    val extractor: UserProfileExtractor,
+    private val extractor: UserProfileExtractor,
 ) {
     GOOGLE(GoogleUserProfileExtractor()),
     NAVER(NaverUserProfileExtractor()),

--- a/friends_server/src/main/kotlin/com/friends/oauth2/OAuth2Dtos.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/OAuth2Dtos.kt
@@ -1,0 +1,14 @@
+package com.friends.oauth2
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class OAuth2AccessTokenResponseDto(
+    @JsonProperty("access_token")
+    val accessToken: String,
+)
+
+data class UserProfileDto(
+    val name: String,
+    val email: String,
+    val imageUrl: String,
+)

--- a/friends_server/src/main/kotlin/com/friends/oauth2/OAuth2Exceptions.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/OAuth2Exceptions.kt
@@ -1,0 +1,13 @@
+package com.friends.oauth2
+
+import com.friends.common.exception.ErrorCode
+
+abstract class OAuth2Exception(
+    val errorCode: ErrorCode,
+) : RuntimeException(errorCode.errorMessage)
+
+class OAuth2NullResponseException : OAuth2Exception(ErrorCode.OAUTH2_NULL_RESPONSE)
+
+class OAuth2AccessTokenFetchFailedException : OAuth2Exception(ErrorCode.OAUTH2_ACCESS_TOKEN_FETCH_FAILED)
+
+class OAuth2UserInfoFetchFailedException : OAuth2Exception(ErrorCode.OAUTH2_USER_INFO_FETCH_FAILED)

--- a/friends_server/src/main/kotlin/com/friends/oauth2/OAuth2Fetcher.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/OAuth2Fetcher.kt
@@ -1,0 +1,65 @@
+package com.friends.oauth2
+
+import com.friends.config.OAuth2Properties
+import com.friends.member.entity.OAuth2Provider
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+import java.nio.charset.StandardCharsets
+
+@Component
+class OAuth2Fetcher(
+    private val oAuth2Properties: OAuth2Properties,
+) {
+    fun getAccessToken(
+        code: String,
+        oAuth2Provider: OAuth2Provider,
+    ): OAuth2AccessTokenResponseDto {
+        val oAuth2Property = oAuth2Properties.get(oAuth2Provider)
+        val requestForm =
+            mapOf(
+                "code" to code,
+                "grant_type" to "authorization_code",
+                "redirect_uri" to oAuth2Property.redirectUrl,
+            )
+
+        return try {
+            WebClient
+                .create()
+                .post()
+                .uri(oAuth2Property.tokenUrl)
+                .headers {
+                    it.setBasicAuth(oAuth2Property.clientId, oAuth2Property.clientSecret)
+                    it.contentType = MediaType.APPLICATION_FORM_URLENCODED
+                    it.accept = listOf(MediaType.APPLICATION_JSON)
+                    it.acceptCharset = listOf(StandardCharsets.UTF_8)
+                }.bodyValue(requestForm)
+                .retrieve()
+                .bodyToMono(OAuth2AccessTokenResponseDto::class.java)
+                .block() ?: throw OAuth2NullResponseException()
+        } catch (e: Exception) {
+            throw OAuth2AccessTokenFetchFailedException()
+        }
+    }
+
+    fun getUserAttributes(
+        accessToken: String,
+        oAuth2Provider: OAuth2Provider,
+    ): Map<String, Any> {
+        val oAuth2Property = oAuth2Properties.get(oAuth2Provider)
+        return try {
+            WebClient
+                .create()
+                .post()
+                .uri(oAuth2Property.userInfoUrl)
+                .headers { headers ->
+                    headers.setBearerAuth(accessToken)
+                }.retrieve()
+                .bodyToMono<Map<String, Any>>()
+                .block() ?: throw OAuth2NullResponseException()
+        } catch (e: Exception) {
+            throw OAuth2UserInfoFetchFailedException()
+        }
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/oauth2/OAuth2Service.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/OAuth2Service.kt
@@ -1,0 +1,18 @@
+package com.friends.oauth2
+
+import com.friends.member.entity.OAuth2Provider
+import org.springframework.stereotype.Service
+
+@Service
+class OAuth2Service(
+    private val oAuth2Fetcher: OAuth2Fetcher,
+) {
+    fun getUserProfile(
+        code: String,
+        oAuth2Provider: OAuth2Provider,
+    ): UserProfileDto {
+        val accessTokenResponseDto = oAuth2Fetcher.getAccessToken(code, oAuth2Provider)
+        val attributes = oAuth2Fetcher.getUserAttributes(accessTokenResponseDto.accessToken, oAuth2Provider)
+        return oAuth2Provider.extract(attributes)
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/oauth2/UserProfileExtractors.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/UserProfileExtractors.kt
@@ -25,7 +25,7 @@ class GoogleUserProfileExtractor : UserProfileExtractor {
  */
 class NaverUserProfileExtractor : UserProfileExtractor {
     override fun extract(attributes: Map<String, Any>): UserProfileDto {
-        val response = attributes["response"] as Map<String, Object>
+        val response = attributes["response"] as Map<String, Any>
         val name = response["name"] as String
         val email = response["email"] as String
         val imageUrl = response["profile_image"] as String

--- a/friends_server/src/main/kotlin/com/friends/oauth2/UserProfileExtractors.kt
+++ b/friends_server/src/main/kotlin/com/friends/oauth2/UserProfileExtractors.kt
@@ -1,0 +1,34 @@
+package com.friends.oauth2
+
+/**
+ * 각각의 OAuth2 에 맞게 데이터를 추출하는 인터페이스
+ * (구글, 네이버 등)
+ */
+interface UserProfileExtractor {
+    fun extract(attributes: Map<String, Any>): UserProfileDto
+}
+
+/**
+ * 구글 OAuth2 에 맞게 데이터를 추출하는 클래스
+ */
+class GoogleUserProfileExtractor : UserProfileExtractor {
+    override fun extract(attributes: Map<String, Any>): UserProfileDto {
+        val name = attributes["name"] as String
+        val email = attributes["email"] as String
+        val imageUrl = attributes["picture"] as String
+        return UserProfileDto(name, email, imageUrl)
+    }
+}
+
+/**
+ * 네이버 OAuth2 에 맞게 데이터를 추출하는 클래스
+ */
+class NaverUserProfileExtractor : UserProfileExtractor {
+    override fun extract(attributes: Map<String, Any>): UserProfileDto {
+        val response = attributes["response"] as Map<String, Object>
+        val name = response["name"] as String
+        val email = response["email"] as String
+        val imageUrl = response["profile_image"] as String
+        return UserProfileDto(name, email, imageUrl)
+    }
+}

--- a/friends_server/src/main/resources/application.yml
+++ b/friends_server/src/main/resources/application.yml
@@ -60,3 +60,17 @@ auth :
   refresh-token-expiration: 604800 # 1 week
   email-code-expiration: 180 #3min
   email-jwt-expiration: 300 #5min
+
+oauth2:
+  google:
+    client-id: ...
+    client-secret: ...
+    redirect-url: http://localhost:3000/oauth2/callback/google
+    token-url: https://www.googleapis.com/oauth2/v4/token
+    user-info-url: https://www.googleapis.com/oauth2/v3/userinfo
+  naver:
+    client_id: ...
+    client-secret: ...
+    redirect-url: http://localhost:3000/oauth2/callback/naver
+    token-url: https://nid.naver.com/oauth2.0/token
+    user-info-url: https://openapi.naver.com/v1/nid/me

--- a/friends_server/src/test/kotlin/com/friends/config/OAuth2PropertiesTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/config/OAuth2PropertiesTest.kt
@@ -1,0 +1,5 @@
+package com.friends.config
+
+import org.junit.jupiter.api.Assertions.*
+
+class OAuth2PropertiesTest


### PR DESCRIPTION
## 📝 Pull Request 내용
oauth2 서비스를 구현하여 유저 정보를 받아올 수 있게 하였습니다.

### 📑 변경 사항
- [ ] OAuth2 API 에서 제공하는 authrization code 를 통해 access token 을 받아와서 access token 으로 유저 데이터를 요청합니다. 
- [ ] 받는 유저 데이터의 형식이 소셜 서비스마다 상이하여 데이터를 추출하는 객체를 추상화해 각 소셜 서비스에 맞게 구현하였습니다.
- [ ] 소셜 서비스에 프로젝트를 등록하고 관련 설정을 applicaiton.yml 에 추가하였습니다.
- [ ] application.yml 을 gitignore 에 추가하였습니다.

### 🔗 관련 이슈
- close #13 

### 💬 기타 참고 사항
- 소셜 서비스 설정의 보안 값을 비워두었습니다. 
노션의 백앤드 섹션의 OAuth2 문서에 적힌 보안 값을 application.yml 의 `...` 부분에 입력해주세요~

