### PR TITLE
Feature/board comment service

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/board/dto/CommentAddDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/dto/CommentAddDto.kt
@@ -1,0 +1,11 @@
+package com.friends.board.dto
+
+import com.friends.board.entity.Board
+import com.friends.common.entity.BaseModifiableEntity
+import com.friends.member.entity.Member
+
+data class CommentAddDto (
+    var text: String,
+    var member: Member,
+    var board: Board,
+) : BaseModifiableEntity()

--- a/friends_server/src/main/kotlin/com/friends/board/dto/CommentDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/dto/CommentDto.kt
@@ -9,3 +9,8 @@ data class CommentAddDto (
     var member: Member,
     var board: Board,
 ) : BaseModifiableEntity()
+
+data class CommentUpdateDto (
+    var text: String,
+)
+

--- a/friends_server/src/main/kotlin/com/friends/board/entity/BoardEntities.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/entity/BoardEntities.kt
@@ -3,6 +3,7 @@ package com.friends.board.entity
 import com.friends.board.dto.BoardFormDto
 import com.friends.common.entity.BaseModifiableEntity
 import com.friends.member.entity.Member
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -11,6 +12,8 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OrderBy
 
 @Entity
 class Board(
@@ -22,6 +25,9 @@ class Board(
     val member: Member,
     @Column(length = 500, nullable = false)
     var content: String,
+    @OneToMany(mappedBy = "board", fetch = FetchType.EAGER, cascade = [CascadeType.REMOVE])
+    @OrderBy("id asc")
+    var comments: List<Comment> = mutableListOf()
 ) : BaseModifiableEntity() {
     fun updateBoard(boardFormDto: BoardFormDto) {
         content = boardFormDto.content

--- a/friends_server/src/main/kotlin/com/friends/board/exception/BoardExceptions.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/exception/BoardExceptions.kt
@@ -1,4 +1,4 @@
-package com.friends.board
+package com.friends.board.exception
 
 import com.friends.common.exception.ErrorCode
 

--- a/friends_server/src/main/kotlin/com/friends/board/exception/CommentExceptions.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/exception/CommentExceptions.kt
@@ -7,3 +7,5 @@ abstract class CommentException (
 ) : RuntimeException(errorCode.errorMessage)
 
 class CommentNotFoundException : CommentException(ErrorCode.NOT_FOUND_COMMENT)
+
+class InvalidCommentAccessException : CommentException(ErrorCode.INVALID_COMMENT_ACCESS)

--- a/friends_server/src/main/kotlin/com/friends/board/exception/CommentExceptions.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/exception/CommentExceptions.kt
@@ -1,0 +1,9 @@
+package com.friends.board.exception
+
+import com.friends.common.exception.ErrorCode
+
+abstract class CommentException (
+    val errorCode: ErrorCode
+) : RuntimeException(errorCode.errorMessage)
+
+class CommentNotFoundException : CommentException(ErrorCode.NOT_FOUND_COMMENT)

--- a/friends_server/src/main/kotlin/com/friends/board/repository/CommentRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/repository/CommentRepository.kt
@@ -4,4 +4,5 @@ import com.friends.board.entity.Comment
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CommentRepository : JpaRepository<Comment, Long> {
+    fun findByBoardIdAndId(boardId: Long, id: Long): Comment?
 }

--- a/friends_server/src/main/kotlin/com/friends/board/repository/CommentRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/repository/CommentRepository.kt
@@ -7,5 +7,5 @@ import java.time.LocalDateTime
 interface CommentRepository : JpaRepository<Comment, Long> {
     fun findByBoardIdAndId(boardId: Long, id: Long): Comment?
     fun findTop20ByBoardIdOrderByCreatedAtAsc(boardId: Long): List<Comment>
-    fun findTop20ByBoardIdAndCreatedAtAfterOrderByCreatedAtAsc(boardId: Long, createdAt: LocalDateTime): List<Comment>
+    fun findTop20ByBoardIdAndCreatedAtAfterOrderByIdAsc(boardId: Long, createdAt: LocalDateTime): List<Comment>
 }

--- a/friends_server/src/main/kotlin/com/friends/board/repository/CommentRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/repository/CommentRepository.kt
@@ -1,0 +1,7 @@
+package com.friends.board.repository
+
+import com.friends.board.entity.Comment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentRepository : JpaRepository<Comment, Long> {
+}

--- a/friends_server/src/main/kotlin/com/friends/board/repository/CommentRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/repository/CommentRepository.kt
@@ -2,7 +2,10 @@ package com.friends.board.repository
 
 import com.friends.board.entity.Comment
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
 
 interface CommentRepository : JpaRepository<Comment, Long> {
     fun findByBoardIdAndId(boardId: Long, id: Long): Comment?
+    fun findTop20ByBoardIdOrderByCreatedAtAsc(boardId: Long): List<Comment>
+    fun findTop20ByBoardIdAndCreatedAtAfterOrderByCreatedAtAsc(boardId: Long, createdAt: LocalDateTime): List<Comment>
 }

--- a/friends_server/src/main/kotlin/com/friends/board/service/BoardCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/BoardCommandService.kt
@@ -1,7 +1,7 @@
 package com.friends.board.service
 
-import com.friends.board.BoardNotFoundException
-import com.friends.board.InvalidBoardAccessException
+import com.friends.board.exception.BoardNotFoundException
+import com.friends.board.exception.InvalidBoardAccessException
 import com.friends.board.dto.BoardFormDto
 import com.friends.board.entity.Board
 import com.friends.board.entity.BoardHashtag

--- a/friends_server/src/main/kotlin/com/friends/board/service/CommentCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/CommentCommandService.kt
@@ -5,6 +5,7 @@ import com.friends.board.exception.BoardNotFoundException
 import com.friends.board.dto.CommentUpdateDto
 import com.friends.board.entity.Comment
 import com.friends.board.exception.CommentNotFoundException
+import com.friends.board.exception.InvalidCommentAccessException
 import com.friends.board.repository.BoardRepository
 import com.friends.board.repository.CommentRepository
 import com.friends.member.MemberNotFoundException
@@ -41,11 +42,13 @@ class CommentCommandService(
     //댓글 삭제
     fun deleteComment(
         boardId: Long,
-        commentId: Long
+        commentId: Long,
+        memberId: Long
     ) {
         val comment = commentRepository.findByBoardIdAndId(boardId, commentId)
-        if(comment == null) {
-            throw CommentNotFoundException()
+            ?: throw CommentNotFoundException()
+        if(comment.member.id != memberId){
+            throw InvalidCommentAccessException()
         }
         commentRepository.delete(comment)
     }
@@ -53,11 +56,13 @@ class CommentCommandService(
     fun updateComment(
         boardId: Long,
         commentId: Long,
-        request: CommentUpdateDto
+        request: CommentUpdateDto,
+        memberId: Long,
     ) {
         val comment = commentRepository.findByBoardIdAndId(boardId, commentId)
-        if(comment == null) {
-            throw CommentNotFoundException()
+            ?: throw CommentNotFoundException()
+        if(comment.member.id != memberId){
+            throw InvalidCommentAccessException()
         }
         comment.updateComment(request.text)
     }

--- a/friends_server/src/main/kotlin/com/friends/board/service/CommentCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/CommentCommandService.kt
@@ -1,8 +1,10 @@
 package com.friends.board.service
 
-import com.friends.board.BoardNotFoundException
 import com.friends.board.dto.CommentAddDto
+import com.friends.board.exception.BoardNotFoundException
+import com.friends.board.dto.CommentUpdateDto
 import com.friends.board.entity.Comment
+import com.friends.board.exception.CommentNotFoundException
 import com.friends.board.repository.BoardRepository
 import com.friends.board.repository.CommentRepository
 import com.friends.member.MemberNotFoundException
@@ -38,9 +40,28 @@ class CommentCommandService(
         return commentRepository.save(savedComment)
     }
 
-    //댓글 수정
-
     //댓글 삭제
+    fun deleteComment(
+        boardId: Long,
+        id: Long
+    ) {
+        val comment = commentRepository.findByBoardIdAndId(boardId, id)
+        if(comment == null) {
+            throw CommentNotFoundException()
+        }
+        commentRepository.delete(comment)
+    }
 
-
+    //댓글 수정
+    fun updateComment(
+        boardId: Long,
+        id: Long,
+        request: CommentUpdateDto
+    ) {
+        val comment = commentRepository.findByBoardIdAndId(boardId, id)
+        if(comment == null) {
+            throw CommentNotFoundException()
+        }
+        comment.updateComment(request.text)
+    }
 }

--- a/friends_server/src/main/kotlin/com/friends/board/service/CommentCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/CommentCommandService.kt
@@ -1,0 +1,46 @@
+package com.friends.board.service
+
+import com.friends.board.BoardNotFoundException
+import com.friends.board.dto.CommentAddDto
+import com.friends.board.entity.Comment
+import com.friends.board.repository.BoardRepository
+import com.friends.board.repository.CommentRepository
+import com.friends.member.MemberNotFoundException
+import com.friends.member.repository.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class CommentCommandService(
+    private val commentRepository: CommentRepository,
+    private val memberRepository: MemberRepository,
+    private val boardRepository: BoardRepository,
+) {
+
+    //댓글 작성
+    fun createComment(
+        boardId: Long,
+        request: CommentAddDto,
+        memberId: Long,
+    ): Comment{
+        val member = memberRepository.findById(memberId).orElseThrow{
+            MemberNotFoundException()
+        }
+        val board = boardRepository.findById(boardId).orElseThrow{
+            BoardNotFoundException()
+        }
+        val savedComment = Comment(
+            text = request.text,
+            board = board,
+            member = member,
+        )
+        return commentRepository.save(savedComment)
+    }
+
+    //댓글 수정
+
+    //댓글 삭제
+
+
+}

--- a/friends_server/src/main/kotlin/com/friends/board/service/CommentCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/CommentCommandService.kt
@@ -19,7 +19,6 @@ class CommentCommandService(
     private val memberRepository: MemberRepository,
     private val boardRepository: BoardRepository,
 ) {
-
     //댓글 작성
     fun createComment(
         boardId: Long,
@@ -39,26 +38,24 @@ class CommentCommandService(
         )
         return commentRepository.save(savedComment)
     }
-
     //댓글 삭제
     fun deleteComment(
         boardId: Long,
-        id: Long
+        commentId: Long
     ) {
-        val comment = commentRepository.findByBoardIdAndId(boardId, id)
+        val comment = commentRepository.findByBoardIdAndId(boardId, commentId)
         if(comment == null) {
             throw CommentNotFoundException()
         }
         commentRepository.delete(comment)
     }
-
     //댓글 수정
     fun updateComment(
         boardId: Long,
-        id: Long,
+        commentId: Long,
         request: CommentUpdateDto
     ) {
-        val comment = commentRepository.findByBoardIdAndId(boardId, id)
+        val comment = commentRepository.findByBoardIdAndId(boardId, commentId)
         if(comment == null) {
             throw CommentNotFoundException()
         }

--- a/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
@@ -3,21 +3,31 @@ package com.friends.board.service
 import com.friends.board.entity.Comment
 import com.friends.board.exception.BoardNotFoundException
 import com.friends.board.repository.BoardRepository
+import com.friends.board.repository.CommentRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
-class CommentQueryService (
+class CommentQueryService(
     private val boardRepository: BoardRepository,
+    private val commentRepository: CommentRepository,
 ){
     //댓글조회
     @Transactional(readOnly = true)
     fun getCommentList(
         boardId: Long,
+        lastCreatedAt: LocalDateTime? = null,
     ): List<Comment> {
-        val board = boardRepository.findById(boardId).orElseThrow{
+        if(!boardRepository.existsById(boardId)) {
             throw BoardNotFoundException()
         }
-        return board.comments.sortedBy { it.createdAt }
+        return if(lastCreatedAt == null){
+            commentRepository.findTop20ByBoardIdOrderByCreatedAtAsc(boardId)
+        } else {
+            commentRepository.findTop20ByBoardIdAndCreatedAtAfterOrderByCreatedAtAsc(
+                boardId, lastCreatedAt
+            )
+        }
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
@@ -1,4 +1,23 @@
 package com.friends.board.service
 
-class CommentQueryService {
+import com.friends.board.entity.Comment
+import com.friends.board.exception.BoardNotFoundException
+import com.friends.board.repository.BoardRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CommentQueryService (
+    private val boardRepository: BoardRepository,
+){
+    //댓글조회
+    @Transactional(readOnly = true)
+    fun getCommentList(
+        boardId: Long,
+    ): List<Comment> {
+        val board = boardRepository.findById(boardId).orElseThrow{
+            throw BoardNotFoundException()
+        }
+        return board.comments
+    }
 }

--- a/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
@@ -1,0 +1,4 @@
+package com.friends.board.service
+
+class CommentQueryService {
+}

--- a/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
@@ -25,7 +25,7 @@ class CommentQueryService(
         return if(lastCreatedAt == null){
             commentRepository.findTop20ByBoardIdOrderByCreatedAtAsc(boardId)
         } else {
-            commentRepository.findTop20ByBoardIdAndCreatedAtAfterOrderByCreatedAtAsc(
+            commentRepository.findTop20ByBoardIdAndCreatedAtAfterOrderByIdAsc(
                 boardId, lastCreatedAt
             )
         }

--- a/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/board/service/CommentQueryService.kt
@@ -18,6 +18,6 @@ class CommentQueryService (
         val board = boardRepository.findById(boardId).orElseThrow{
             throw BoardNotFoundException()
         }
-        return board.comments
+        return board.comments.sortedBy { it.createdAt }
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
@@ -51,7 +51,8 @@ enum class ErrorCode(
     CHAT_ROOM_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, -17006, "존재하지 않는 채팅방 카테고리입니다."),
 
     // Comment API error 18000대
-    NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, -18001, "존재하지 않는 댓글입니다.")
+    NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, -18001, "존재하지 않는 댓글입니다."),
+    INVALID_COMMENT_ACCESS(HttpStatus.FORBIDDEN, -18002, "댓글에 대한 유효하지 않은 접근입니다.")
 
 
 }

--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
@@ -49,4 +49,9 @@ enum class ErrorCode(
     CHAT_ROOM_CATEGORY_INVALID_SIZE(HttpStatus.BAD_REQUEST, -17004, "채팅방 카테고리는 최소 1개 이상 선택해주세요."),
     CHAT_ROOM_POSITIVE_LIKE_COUNT(HttpStatus.BAD_REQUEST, -17005, "채팅방 좋아요 수는 0 이상이어야 합니다."),
     CHAT_ROOM_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, -17006, "존재하지 않는 채팅방 카테고리입니다."),
+
+    // Comment API error 18000대
+    NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, -18001, "존재하지 않는 댓글입니다.")
+
+
 }

--- a/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.friends.common.exception
 
-import com.friends.board.BoardException
+import com.friends.board.exception.BoardException
+import com.friends.board.exception.CommentException
 import com.friends.chat.ChatException
 import com.friends.email.EmailException
 import com.friends.member.MemberExceptions
@@ -69,6 +70,14 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(ChatException::class)
     fun handleChatException(ex: ChatException): ResponseEntity<Any> {
         log.error("Chat Exception", ex)
+        return ResponseEntity
+            .status(ex.errorCode.httpStatus)
+            .body(ErrorResponse.of(ex.errorCode, ex.message))
+    }
+
+    @ExceptionHandler(CommentException::class)
+    fun handleCommentException(ex: CommentException): ResponseEntity<Any> {
+        log.error("Comment Exception", ex)
         return ResponseEntity
             .status(ex.errorCode.httpStatus)
             .body(ErrorResponse.of(ex.errorCode, ex.message))

--- a/friends_server/src/test/kotlin/com/friends/board/service/BoardCommandServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/board/service/BoardCommandServiceTest.kt
@@ -1,8 +1,8 @@
 package com.friends.board.service
 
-import com.friends.board.BoardNotFoundException
+import com.friends.board.exception.BoardNotFoundException
 import com.friends.board.INVALID_BOARD_ID
-import com.friends.board.InvalidBoardAccessException
+import com.friends.board.exception.InvalidBoardAccessException
 import com.friends.board.NON_AUTHORIZED_MEMBER_ID
 import com.friends.board.REQUEST_MEMBER_ID
 import com.friends.board.boardFormDto


### PR DESCRIPTION
## 📝 Pull Request 내용

게시글과 댓글의 연관관계를 구현하고 CRUD 서비스기능을 작성하였습니다.

### 📑 변경 사항
- [ ] board 엔티티에 양방향 매핑을 해주어 댓글 조회가 가능하게끔 설정
- [ ] commentCommandService, commentQueryService에 댓글 작성, 삭제, 수정, 삭제 구현
- [ ] service 단에 필요한 commentDto(add dto, update dto) 작성

### 🔗 관련 이슈
- #58 

### 💬 기타 참고 사항
- 일단 글 삭제 시 댓글 삭제(cascade type = remove)으로 구현함
