### PR TITLE
Feature/register with profile

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/security/AuthDtos.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/AuthDtos.kt
@@ -13,7 +13,7 @@ data class LoginResponseDto(
 )
 
 data class RegisterRequestDto(
-    val emailAuthToken: String,
+    val authToken: String,
     val email: String,
     val password: String,
     val nickname: String,
@@ -57,6 +57,11 @@ data class LogoutRequestDto(
 )
 
 data class CheckNicknameResponseDto(
+    val isValid: Boolean,
+    val message: String,
+)
+
+data class CheckEmailResponseDto(
     val isValid: Boolean,
     val message: String,
 )

--- a/friends_server/src/main/kotlin/com/friends/security/AuthDtos.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/AuthDtos.kt
@@ -24,10 +24,14 @@ data class AtRtDto(
     val refreshToken: String,
 )
 
-data class OAuth2LoginSuccessDto(
-    val firstLogin: Boolean,
-    val accessToken: String,
-    val refreshToken: String,
+data class OAuth2LoginDto(
+    val isRegistered: Boolean,
+    val memberId: Long? = null,
+    val accessToken: String? = null,
+    val refreshToken: String? = null,
+    val email: String? = null,
+    val nickname: String? = null,
+    val imageUrl: String? = null,
 )
 
 data class OAuth2LoginRequestDto(
@@ -36,9 +40,12 @@ data class OAuth2LoginRequestDto(
 )
 
 data class OAuth2LoginResponseDto(
-    val memberId: Long,
-    val accessToken: String,
-    val firstLogin: Boolean,
+    val isRegistered: Boolean,
+    val memberId: Long? = null,
+    val accessToken: String? = null,
+    val email: String? = null,
+    val nickname: String? = null,
+    val imageUrl: String? = null,
 )
 
 data class RefreshResponseDto(

--- a/friends_server/src/main/kotlin/com/friends/security/controller/AuthController.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/controller/AuthController.kt
@@ -62,18 +62,30 @@ class AuthController(
             .body(LoginResponseDto(memberId, atRtDto.accessToken))
     }
 
-    @PostMapping("/oauth2-login")
+    @PostMapping("/oauth2")
     fun oauth2Login(
         @RequestBody oauth2LoginRequestDto: OAuth2LoginRequestDto,
     ): ResponseEntity<OAuth2LoginResponseDto> {
-        val oauth2LoginSuccessDto = authService.loginByOAuth2(oauth2LoginRequestDto.code, oauth2LoginRequestDto.provider)
-        val memberId = atRtService.getMemberId(oauth2LoginSuccessDto.accessToken)
+        val oauth2LoginDto = authService.loginByOAuth2(oauth2LoginRequestDto.code, oauth2LoginRequestDto.provider)
+        if (oauth2LoginDto.isRegistered) {
+            val memberId = atRtService.getMemberId(oauth2LoginDto.accessToken!!)
 
-        return ResponseEntity
-            .ok()
-            // refresh token 을 쿠키로 전달합니다.
-            .header(COOKIE_HEARER, getRefreshTokenCookie(oauth2LoginSuccessDto.refreshToken).toString())
-            .body(OAuth2LoginResponseDto(memberId, oauth2LoginSuccessDto.accessToken, oauth2LoginSuccessDto.firstLogin))
+            return ResponseEntity
+                .ok()
+                .header(COOKIE_HEARER, getRefreshTokenCookie(oauth2LoginDto.refreshToken!!).toString())
+                .body(OAuth2LoginResponseDto(memberId = memberId, accessToken = oauth2LoginDto.accessToken, isRegistered = true))
+        } else {
+            return ResponseEntity
+                .ok()
+                .body(
+                    OAuth2LoginResponseDto(
+                        isRegistered = false,
+                        email = oauth2LoginDto.email,
+                        nickname = oauth2LoginDto.nickname,
+                        imageUrl = oauth2LoginDto.imageUrl,
+                    ),
+                )
+        }
     }
 
     @PostMapping("/refresh")

--- a/friends_server/src/main/kotlin/com/friends/security/controller/AuthController.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/controller/AuthController.kt
@@ -1,6 +1,7 @@
 package com.friends.security.controller
 
 import com.friends.jwt.AtRtService
+import com.friends.security.CheckEmailResponseDto
 import com.friends.security.CheckNicknameResponseDto
 import com.friends.security.LoginRequestDto
 import com.friends.security.LoginResponseDto
@@ -36,7 +37,7 @@ class AuthController(
         @RequestBody registerRequestDto: RegisterRequestDto,
     ): ResponseEntity<String> {
         authService.register(
-            registerRequestDto.emailAuthToken,
+            registerRequestDto.authToken,
             registerRequestDto.email,
             registerRequestDto.password,
             registerRequestDto.nickname,
@@ -126,6 +127,11 @@ class AuthController(
     fun checkNickname(
         @RequestParam nickname: String,
     ): ResponseEntity<CheckNicknameResponseDto> = ResponseEntity.ok(authService.validateNickname(nickname))
+
+    @GetMapping("/check-email")
+    fun checkEmail(
+        @RequestParam email: String,
+    ): ResponseEntity<CheckEmailResponseDto> = ResponseEntity.ok(authService.validateEmail(email))
 
     /**
      * cookie 를 생성하여 문자열로 변환시 아래와 같은 형태로 변환됩니다.

--- a/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
@@ -8,7 +8,7 @@ import com.friends.member.repository.MemberRepository
 import com.friends.oauth2.OAuth2Service
 import com.friends.security.AtRtDto
 import com.friends.security.CheckNicknameResponseDto
-import com.friends.security.OAuth2LoginSuccessDto
+import com.friends.security.OAuth2LoginDto
 import com.friends.security.securityException.EmailDuplicateException
 import com.friends.security.securityException.EmailNotFoundException
 import com.friends.security.securityException.InvalidNicknameException
@@ -126,36 +126,23 @@ class AuthService(
         }
     }
 
-    @Transactional
     fun loginByOAuth2(
         code: String,
         oAuth2Provider: OAuth2Provider,
-    ): OAuth2LoginSuccessDto {
+    ): OAuth2LoginDto {
         val userProfile = oAuth2Service.getUserProfile(code, oAuth2Provider)
 
-        var firstLogin = false
-
-        // 이미 가입되어 있다면 유저를 불러오고 없다면 새로 생성합니다.
         var user = memberRepository.findByEmail(userProfile.email)
-        if (user == null) {
-            user =
-                Member.createUser(
-                    nickname = userProfile.name,
-                    email = userProfile.email,
-                    oauth2Provider = oAuth2Provider,
-                    imageUrl = userProfile.imageUrl,
-                )
-            memberRepository.save(user)
-            firstLogin = true
+        // 이미 가입된 사용자인 경우
+        if (user != null) {
+            if (user.oauth2Provider != oAuth2Provider) {
+                throw EmailDuplicateException()
+            }
+            val atRtoDto = atRtService.createAtRt(user.id, user.authorities.map { SimpleGrantedAuthority(it.role.name) })
+            return OAuth2LoginDto(isRegistered = true, memberId = user.id, accessToken = atRtoDto.accessToken, refreshToken = atRtoDto.refreshToken)
+        } else { // 가입되지 않은 사용자인 경우
+            return OAuth2LoginDto(isRegistered = false, email = userProfile.email, nickname = userProfile.name, imageUrl = userProfile.imageUrl)
         }
-
-        // 이미 가입된 이메일의 소셜 서비스가 요청된 소셜 서비스와 다르다면 예외를 발생시킵니다.
-        if (user.oauth2Provider != oAuth2Provider) {
-            throw EmailDuplicateException()
-        }
-
-        val atRtDto = atRtService.createAtRt(user.id, user.authorities.map { SimpleGrantedAuthority(it.role.name) })
-        return OAuth2LoginSuccessDto(firstLogin, atRtDto.accessToken, atRtDto.refreshToken)
     }
 
     fun logout(

--- a/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
@@ -7,6 +7,7 @@ import com.friends.member.entity.OAuth2Provider
 import com.friends.member.repository.MemberRepository
 import com.friends.oauth2.OAuth2Service
 import com.friends.security.AtRtDto
+import com.friends.security.CheckEmailResponseDto
 import com.friends.security.CheckNicknameResponseDto
 import com.friends.security.OAuth2LoginDto
 import com.friends.security.securityException.EmailDuplicateException
@@ -125,6 +126,13 @@ class AuthService(
             CheckNicknameResponseDto(true, "사용 가능한 닉네임입니다.")
         }
     }
+
+    fun validateEmail(email: String): CheckEmailResponseDto =
+        if (memberRepository.existsByEmail(email)) {
+            CheckEmailResponseDto(false, "이미 사용 중인 이메일입니다.")
+        } else {
+            CheckEmailResponseDto(true, "사용 가능한 이메일입니다.")
+        }
 
     fun loginByOAuth2(
         code: String,


### PR DESCRIPTION
## 📝 Pull Request 내용
현재는 oauth2 를 사용하면 바로 회원가입이 되는데,
이걸 바로 회원가입 시키지 않고 추가로 프로필 정보를 입력해야 회원가입이 되도록 변경하고 있습니다.

### 📑 변경 사항
- [ ] oauth2 로 성공적으로 유저 정보를 받아오면, 이미 회원가입 된 상태라면 로그인 시키고, 아닌 상태라면 유저 정보를 클라이언트에게 반환합니다.
- [ ] 이메일 인증 절차를 별도의 API 로 분리합니다.

### 🔗 관련 이슈
- #66 

### 💬 기타 참고 사항
- 현재 회원 가입 시 이메일, 패스워드만 필요하고 프로필 정보는 없어도 되는 상황입니다.
  일단 여기까지만 진행하고 다음 PR 에 추가해보겠습니다. 
