### PR TITLE
feature/logout

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/security/AuthDtos.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/AuthDtos.kt
@@ -46,7 +46,7 @@ data class RefreshResponseDto(
 )
 
 data class LogoutRequestDto(
-    val accessToken: String,
+    val accessToken: String?,
 )
 
 data class CheckNicknameResponseDto(

--- a/friends_server/src/main/kotlin/com/friends/security/controller/AuthController.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/controller/AuthController.kt
@@ -92,7 +92,7 @@ class AuthController(
     @PostMapping("/logout")
     fun logout(
         @RequestBody logoutRequestDto: LogoutRequestDto,
-        @CookieValue refreshToken: String,
+        @CookieValue(required = false) refreshToken: String,
     ): ResponseEntity<String> {
         // accessToken 과 refreshToken 을 삭제합니다.
         authService.logout(logoutRequestDto.accessToken, refreshToken)

--- a/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
@@ -159,11 +159,17 @@ class AuthService(
     }
 
     fun logout(
-        accessToken: String,
-        refreshToken: String,
+        accessToken: String?,
+        refreshToken: String?,
     ) {
-        atRtService.deleteAccessToken(accessToken)
-        atRtService.deleteRefreshToken(refreshToken)
+        accessToken?.let { accessToken ->
+            atRtService.getRefreshToken(accessToken)?.let { atRtService.deleteRefreshToken(it) }
+            atRtService.deleteAccessToken(accessToken)
+        }
+        refreshToken?.let { refreshToken ->
+            atRtService.getAccessToken(refreshToken)?.let { atRtService.deleteAccessToken(it) }
+            atRtService.deleteRefreshToken(refreshToken)
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## 📝 Pull Request 내용

로그아웃 API 에 명세서에 AT, RT 이 필수로 포함되지 않아도 동작하도록 작성하였는데,
현재 필수로 받도록 되어 있어 수정하였습니다.

API 명세서 내용
- accessToken 과 refreshToken 이 모두 주어진 경우 
두 토큰 모두 비활성화 시킵니다.
- accessToken 만 주어진 경우 
accessToken 으로 refreshToken 을 찾아 두 토큰 모두 비활성화시킵니다.
- refreshToken 만 주어진 경우
refreshToken 으로 accessToken 을 찾아 두 토큰 모두 비활성화시킵니다.
- 모두 주어지지 않은 경우
아무것도 하지 않습니다.

### 📑 변경 사항
- [ ] logout 의 파라미터인 accessToken 과 refreshToken 이 null 값을 허용하도록 변경하였습니다.
- [ ] logout 서비스를 API 명세서 내용과 맞도록 수정하였습니다.

### 🔗 관련 이슈
- 이슈는 발행하지 않았습니다.
