### PR TITLE
Feature/send message

### DIFF
--- a/friends_server/build.gradle.kts
+++ b/friends_server/build.gradle.kts
@@ -63,6 +63,9 @@ dependencies {
     // aws
     implementation("com.amazonaws:aws-java-sdk-s3:1.12.375")
 
+    // websocket
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
+
     // Test
     testImplementation(platform("org.junit:junit-bom:5.10.2"))
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatRoomWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatRoomWebSocketHandler.kt
@@ -1,0 +1,54 @@
+package com.friends.chat.websocket
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.CloseStatus
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import org.springframework.web.socket.handler.TextWebSocketHandler
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
+
+@Component
+class ChatRoomWebSocketHandler : TextWebSocketHandler() {
+    private val log = LoggerFactory.getLogger(ChatRoomWebSocketHandler::class.java)
+    private val objectMapper = jacksonObjectMapper()
+    // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
+    private val chatRooms: MutableMap<String, MutableSet<WebSocketSession>> = ConcurrentHashMap()
+
+    override fun afterConnectionEstablished(session: WebSocketSession) {
+        val chatRoomId = getChatRoomId(session)
+        chatRooms.computeIfAbsent(chatRoomId) { CopyOnWriteArraySet() }
+        chatRooms[chatRoomId]?.add(session)
+        log.debug("User connected to chat room: $chatRoomId")
+    }
+
+    override fun handleTextMessage(
+        session: WebSocketSession,
+        message: TextMessage,
+    ) {
+        val chatRoomId = getChatRoomId(session)
+        val sessions = chatRooms[chatRoomId]
+        sessions?.forEach { s ->
+            if (s.isOpen) {
+                s.sendMessage(TextMessage(message.payload))
+            }
+        }
+    }
+
+    override fun afterConnectionClosed(
+        session: WebSocketSession,
+        status: CloseStatus,
+    ) {
+        val chatRoomId = getChatRoomId(session)
+        chatRooms[chatRoomId]?.remove(session)
+        log.debug("User disconnected from chat room: $chatRoomId")
+    }
+
+    // 채팅방 ID를 URI에서 추출하는 함수
+    private fun getChatRoomId(session: WebSocketSession): String {
+        val uri = session.uri.toString()
+        return uri.substringAfterLast("/")
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
@@ -49,7 +49,7 @@ class SpringSecurityConfig(
                     "/swagger-ui/**",
                     "/v3/api-docs/**",
                 ).permitAll()
-                .requestMatchers("/api/user/**")
+                .requestMatchers("/api/user/**", "ws/chatRoom/**")
                 .hasAuthority(Role.ROLE_USER.name)
                 .requestMatchers("/api/admin/**")
                 .hasAuthority(Role.ROLE_ADMIN.name)

--- a/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
@@ -1,0 +1,19 @@
+package com.friends.config
+
+import com.friends.chat.websocket.ChatRoomWebSocketHandler
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.socket.config.annotation.EnableWebSocket
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
+
+@Configuration
+@EnableWebSocket
+class WebSocketConfig(
+    private val chatRoomWebSocketHandler: ChatRoomWebSocketHandler,
+) : WebSocketConfigurer {
+    override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
+        registry
+            .addHandler(chatRoomWebSocketHandler, "/ws/chatRoom/{chatRoomId}")
+            .setAllowedOrigins("*") // CORS 허용
+    }
+}


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] 실시간 양방향 채팅을 위한 기초적인 웹소켓 프레임을 구현하였습니다.
- [ ] 유저만 실시간 양방향 채팅을 보낼 수 있도록 Spring Security 권한을 설정하였습니다.

### 🔗 관련 이슈
- #64 

### 💬 기타 참고 사항
- postman 에서도 웹소켓의 테스트가 가능하더라구요!
[참고자료](https://senslife.tistory.com/52) 이것 보고 테스트해봤는데 실시간 양방향 채팅이 잘 구현된 것 같습니다!

직접 해보고 싶으시면 자료를 그대로 따라하시되 header 에 `Authorization` 을 key 값으로 value 에 `Bearer {access token}` 을 넣어주시면 연결 될 거에요~

