### PR TITLE
Feature/send message by json

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
@@ -1,0 +1,32 @@
+package com.friends.chat.dto
+
+import java.time.LocalDateTime
+
+data class ChatReceiveMessageDto(
+    val senderId: Long,
+    val senderName: String,
+    val senderProfileImageUrl: String,
+    val message: String,
+)
+
+data class ChatSendMessageDto(
+    val senderId: Long,
+    val senderName: String,
+    val senderProfileImageUrl: String,
+    val message: String,
+    val sendTime: LocalDateTime,
+) {
+    companion object {
+        fun from(
+            chatReceiveMessageDto: ChatReceiveMessageDto,
+            sendTime: LocalDateTime,
+        ): ChatSendMessageDto =
+            ChatSendMessageDto(
+                senderId = chatReceiveMessageDto.senderId,
+                senderName = chatReceiveMessageDto.senderName,
+                senderProfileImageUrl = chatReceiveMessageDto.senderProfileImageUrl,
+                message = chatReceiveMessageDto.message,
+                sendTime = sendTime,
+            )
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
@@ -15,18 +15,4 @@ data class ChatSendMessageDto(
     val senderProfileImageUrl: String,
     val message: String,
     val sendTime: LocalDateTime,
-) {
-    companion object {
-        fun from(
-            chatReceiveMessageDto: ChatReceiveMessageDto,
-            sendTime: LocalDateTime,
-        ): ChatSendMessageDto =
-            ChatSendMessageDto(
-                senderId = chatReceiveMessageDto.senderId,
-                senderName = chatReceiveMessageDto.senderName,
-                senderProfileImageUrl = chatReceiveMessageDto.senderProfileImageUrl,
-                message = chatReceiveMessageDto.message,
-                sendTime = sendTime,
-            )
-    }
-}
+)

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatRoomWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatRoomWebSocketHandler.kt
@@ -36,7 +36,14 @@ class ChatRoomWebSocketHandler : TextWebSocketHandler() {
             val sessions = chatRooms[chatRoomId]
             sessions?.forEach { s ->
                 if (s.isOpen) {
-                    val chatSendMessageDto = ChatSendMessageDto.from(chatMessage, LocalDateTime.now())
+                    val chatSendMessageDto =
+                        ChatSendMessageDto(
+                            senderId = chatMessage.senderId,
+                            senderName = chatMessage.senderName,
+                            senderProfileImageUrl = chatMessage.senderProfileImageUrl,
+                            message = chatMessage.message,
+                            sendTime = LocalDateTime.now(),
+                        )
                     s.sendMessage(TextMessage(JsonUtil.toJson(chatSendMessageDto)))
                 }
             }

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatRoomWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatRoomWebSocketHandler.kt
@@ -1,19 +1,21 @@
 package com.friends.chat.websocket
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.friends.chat.dto.ChatReceiveMessageDto
+import com.friends.chat.dto.ChatSendMessageDto
+import com.friends.common.util.JsonUtil
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
+import java.time.LocalDateTime
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
 
 @Component
 class ChatRoomWebSocketHandler : TextWebSocketHandler() {
     private val log = LoggerFactory.getLogger(ChatRoomWebSocketHandler::class.java)
-    private val objectMapper = jacksonObjectMapper()
     // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
     private val chatRooms: MutableMap<String, MutableSet<WebSocketSession>> = ConcurrentHashMap()
 
@@ -28,12 +30,19 @@ class ChatRoomWebSocketHandler : TextWebSocketHandler() {
         session: WebSocketSession,
         message: TextMessage,
     ) {
-        val chatRoomId = getChatRoomId(session)
-        val sessions = chatRooms[chatRoomId]
-        sessions?.forEach { s ->
-            if (s.isOpen) {
-                s.sendMessage(TextMessage(message.payload))
+        try {
+            val chatMessage = JsonUtil.fromJson<ChatReceiveMessageDto>(message.payload)
+            val chatRoomId = getChatRoomId(session)
+            val sessions = chatRooms[chatRoomId]
+            sessions?.forEach { s ->
+                if (s.isOpen) {
+                    val chatSendMessageDto = ChatSendMessageDto.from(chatMessage, LocalDateTime.now())
+                    s.sendMessage(TextMessage(JsonUtil.toJson(chatSendMessageDto)))
+                }
             }
+            log.debug("Received message: $chatMessage")
+        } catch (e: Exception) {
+            log.error("Failed to parse message", e)
         }
     }
 

--- a/friends_server/src/main/kotlin/com/friends/common/util/JsonUtil.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/util/JsonUtil.kt
@@ -1,0 +1,23 @@
+package com.friends.common.util
+
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+object JsonUtil {
+    val objectMapper =
+        jacksonObjectMapper()
+            .registerModules(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // ISO-8601 형식 활성화 -> "2024-12-19T12:31:49.478613" 형식으로 출력
+
+    /**
+     * JSON 문자열을 객체로 변환
+     * inline 으로 선언된 함수는 호출 시 함수의 본문이 호출문으로 대체되는 함수입니다.
+     * reified 키워드는 함수의 타입 매개변수를 런타임에 알 수 있게 해줍니다.
+     */
+    inline fun <reified T> fromJson(json: String): T = objectMapper.readValue(json)
+
+    // 객체를 JSON 문자열로 변환
+    fun toJson(obj: Any): String = objectMapper.writeValueAsString(obj)
+}


### PR DESCRIPTION
## 📝 Pull Request 내용
웹소켓에서 메세지 전송, 받기 양식을 json 으로 이뤄지도록 변경하였습니다.

### 📑 변경 사항
- [ ] json 형식을 data class 로 변환하고 data class 를 json 형식으로 변환할 목적으로 JsonUtil 클래스를 생성하였습니다.
- [ ] 메세지 전송, 받기 dto 를 구현하였습니다.
- [ ] 웹소켓 연결시 주고 받는 데이터가 json 형식이 될 수 있도록 변경하였습니다.

### 🔗 관련 이슈
- #91 

### 💬 기타 참고 사항

JsonUtil 클래스에서 `inline` 과 `reified` 를 사용하였는데, 생소한 문법이였기 때문에 왜 사용했는지 말씀드릴게요..!

objectmapper 는 json 형태의 문자열을 자바 클래스로 변환해주는 모듈입니다.
이 모듈을 사용할 때는 런타임 시 변환하는 자바 클래스를 알고 있어야한다는 조건이 있습니다.
```kotlin
inline fun <reified T> fromJson(json: String): T = objectMapper.readValue(json)
``` 
위 처럼 사용하지 않고 아래 처럼 사용한다면 에러가 발생합니다.
```kotlin
fun <T> fromJson(json: String): T = objectMapper.readValue(json)
```
그 이유는 제네릭 타입의 T 클래스는 컴파일 타임에는 어떤 클래스인지 알 수 있지만 런타임 시에는 알 수 없다고 합니다. [참고자료](https://docs.oracle.com/javase/tutorial/java/generics/erasure.html)
예를 들어 `List<String>`, `List<Int>` 와 같은 자료구조도 제네릭 T 를 사용하는데, 컴파일 타임에는 List 클래스 안에 어떤 클래스가 들어 있는지 알 수 있지만 런타임 시에는 List 클래스라는 것만 알지 안에 어떤 클래스가 들어있는지 알 수 없습니다.
참고 자료에 따르면 하위 버전과의 호환성과 JVM 상에서의 편의성 때문에 이렇게 설계되었다고 하네요..!!

`inline` 함수는 함수를 참조하여 호출하지 않고 직접 함수 내부를 실행한다고 하는데 예를 들어
```kotlin
fun main() {
    printHello()
}

inline fun printHello() {
    print("Hello ")
    println("World")
}
```
위처럼 코드를 짜면 실제로는 아래가 실행됩니다.
```kotlin
fun main() {
    print("Hello ")
    println("World")
}
```

따라서 런타임 시에 함수 내부의 어떤 코드가 실행되는지 알 수 있고 `reified` 는 이 특성을 이용해 제네릭 T 클래스가 런타임 시에 알 수 있는 값이라는 것을 보장해줍니다. ( 따라서 `reified` 는 `inline` 과 세트로 사용되야 하고 혼자 쓰면 에러가 발생합니다.)

정리하자면 objectmapper 모듈은 런타임 시에 어떤 클래스로 매핑할 지 알고 있어야하는데, 제네릭 T 클래스는 런타임 시에 어떤 클래스인지 알 수 없습니다. 
따라서 `inline` 과 `reified` 를 사용하여 이 문제를 해결하였습니다.
`inline` 은 함수의 내부 구조를 직접 호출하기 때문에 런타임 시에 제네릭 T 클래스를 알 수 있고, 이를 `refied` 키워드를 통해 명시해줄 수 있습니다.

[참고자료 reified function](https://www.baeldung.com/kotlin/reified-functions)