### PR TITLE
fix/error_handler

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/GlobalExceptionHandler.kt
@@ -83,11 +83,11 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
             .body(ErrorResponse.of(ex.errorCode, ex.message))
     }
 
-    @ExceptionHandler(Exception::class)
-    fun handleException(ex: Exception): ResponseEntity<Any> {
-        log.error("Exception", ex)
-        return ResponseEntity
-            .status(ErrorCode.INTERNAL_SERVER_ERROR.httpStatus)
-            .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, ex.message))
-    }
+//    @ExceptionHandler(Exception::class)
+//    fun handleException(ex: Exception): ResponseEntity<Any> {
+//        log.error("Exception", ex)
+//        return ResponseEntity
+//            .status(ex.httpStatus)
+//            .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, ex.message))
+//    }
 }


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] globalExceptionHandler 에 Exception 에러를 핸들링하는 부분을 주석처리하였습니다.

### 💬 기타 참고 사항
- 원래 Exception 으로 백앤드에서 처리하지 않는 에러는 500으로 한 이유가 백앤드에서 의도하지 않았던 에러를 모두 잡아서 구현할 생각이었습니다. 
하지만 너무 다양한 에러가 발생하여 이를 모두 잡기가 어렵다고 느꼈습니다.(Exception 을 걸고 난 뒤부터 spring security 에서 발생하는 다양한 에러가 모두 500으로 나가서 API 명세서 대로 동작하지 않더군요..;;)
따라서 spring 에서 구현된 에러를 사용하고 status code 로 반환하도록 이를 해제하였습니다.
