### PR TITLE
feature/multi_part_form_data_converter

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/common/converter/MultipartJackson2HttpMessageConverter.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/converter/MultipartJackson2HttpMessageConverter.kt
@@ -1,0 +1,26 @@
+package com.friends.common.converter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.http.MediaType
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter
+import org.springframework.stereotype.Component
+import java.lang.reflect.Type
+
+// "Content-Type: multipart/form-data" 헤더를 지원하는 HTTP 요청 변환기
+@Component
+class MultipartJackson2HttpMessageConverter(
+    objectMapper: ObjectMapper,
+) : AbstractJackson2HttpMessageConverter(objectMapper, MediaType.APPLICATION_OCTET_STREAM) {
+    override fun canWrite(
+        clazz: Class<*>,
+        mediaType: MediaType?,
+    ): Boolean = false
+
+    override fun canWrite(
+        type: Type?,
+        clazz: Class<*>,
+        mediaType: MediaType?,
+    ): Boolean = false
+
+    override fun canWrite(mediaType: MediaType?): Boolean = false
+}


### PR DESCRIPTION
## 📝 Pull Request 내용
Swagger에서 Content type 'application/octet-stream' not supported (415)에러 발생
### 📑 변경 사항
- muti-part-form-data를 지원하도록 converter 작성

### 💬 기타 참고 사항
[참고 블로그](https://velog.io/@zvyg1023/Spring-Boot-Swagger%EC%97%90%EC%84%9C-ReqeustPart%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EC%97%AC-MultiPartFile%EA%B3%BC-DTO-%EC%B2%98%EB%A6%AC-%EC%8B%9C-Content-type-applicationoctet-stream-not-supported-%EC%98%A4%EB%A5%98-%ED%95%B4%EA%B2%B0)