### PR TITLE
Feature/send message with db

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
@@ -3,10 +3,10 @@ package com.friends.chat.dto
 import com.friends.message.entity.MessageType
 import java.time.LocalDateTime
 
+/**
+ * 채팅 웹소켓에서 메세지 전송은 로그인된 유저만 이용할 수 있기 때문에 senderId는 SecurityContextHolder에서 가져옵니다.
+ */
 data class ChatReceiveMessageDto(
-    val senderId: Long,
-    val senderName: String,
-    val senderProfileImageUrl: String,
     val message: String,
 )
 

--- a/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
@@ -1,5 +1,6 @@
 package com.friends.chat.dto
 
+import com.friends.message.entity.MessageType
 import java.time.LocalDateTime
 
 data class ChatReceiveMessageDto(
@@ -15,4 +16,5 @@ data class ChatSendMessageDto(
     val senderProfileImageUrl: String,
     val message: String,
     val sendTime: LocalDateTime,
+    val type: MessageType,
 )

--- a/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
@@ -12,8 +12,6 @@ data class ChatReceiveMessageDto(
 
 data class ChatSendMessageDto(
     val senderId: Long,
-    val senderName: String,
-    val senderProfileImageUrl: String,
     val message: String,
     val sendTime: LocalDateTime,
     val type: MessageType,

--- a/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
@@ -18,6 +18,11 @@ interface ChatRoomMemberRepository :
     JpaRepository<ChatRoomMember, Long>,
     ChatRoomMemberCustomRepository {
     fun countByChatRoom(chatRoom: ChatRoom): Int
+
+    fun findByChatRoomAndMember(
+        chatRoom: ChatRoom,
+        member: Member,
+    ): ChatRoomMember?
 }
 
 interface ChatRoomMemberCustomRepository {

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatRoomWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatRoomWebSocketHandler.kt
@@ -3,54 +3,40 @@ package com.friends.chat.websocket
 import com.friends.chat.dto.ChatReceiveMessageDto
 import com.friends.chat.dto.ChatSendMessageDto
 import com.friends.common.util.JsonUtil
-import org.slf4j.LoggerFactory
+import com.friends.message.service.MessageService
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
 import java.time.LocalDateTime
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArraySet
 
 @Component
-class ChatRoomWebSocketHandler : TextWebSocketHandler() {
-    private val log = LoggerFactory.getLogger(ChatRoomWebSocketHandler::class.java)
-    // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
-    private val chatRooms: MutableMap<String, MutableSet<WebSocketSession>> = ConcurrentHashMap()
-
+class ChatRoomWebSocketHandler(
+    private val messageService: MessageService,
+) : TextWebSocketHandler() {
     override fun afterConnectionEstablished(session: WebSocketSession) {
         val chatRoomId = getChatRoomId(session)
-        chatRooms.computeIfAbsent(chatRoomId) { CopyOnWriteArraySet() }
-        chatRooms[chatRoomId]?.add(session)
-        log.debug("User connected to chat room: $chatRoomId")
+        messageService.connectChatRoom(chatRoomId, session)
+        // TODO : 채팅방 입장 실패 시 에러 처리
     }
 
     override fun handleTextMessage(
         session: WebSocketSession,
         message: TextMessage,
     ) {
-        try {
-            val chatMessage = JsonUtil.fromJson<ChatReceiveMessageDto>(message.payload)
-            val chatRoomId = getChatRoomId(session)
-            val sessions = chatRooms[chatRoomId]
-            sessions?.forEach { s ->
-                if (s.isOpen) {
-                    val chatSendMessageDto =
-                        ChatSendMessageDto(
-                            senderId = chatMessage.senderId,
-                            senderName = chatMessage.senderName,
-                            senderProfileImageUrl = chatMessage.senderProfileImageUrl,
-                            message = chatMessage.message,
-                            sendTime = LocalDateTime.now(),
-                        )
-                    s.sendMessage(TextMessage(JsonUtil.toJson(chatSendMessageDto)))
-                }
-            }
-            log.debug("Received message: $chatMessage")
-        } catch (e: Exception) {
-            log.error("Failed to parse message", e)
-        }
+        val chatMessage = JsonUtil.fromJson<ChatReceiveMessageDto>(message.payload)
+        val chatRoomId = getChatRoomId(session)
+        val chatSendMessageDto =
+            ChatSendMessageDto(
+                senderId = chatMessage.senderId,
+                senderName = chatMessage.senderName,
+                senderProfileImageUrl = chatMessage.senderProfileImageUrl,
+                message = chatMessage.message,
+                sendTime = LocalDateTime.now(),
+            )
+        messageService.sendMessage(chatRoomId, chatSendMessageDto)
+        // TODO : 메세지 전송 실패 시 에러 처리
     }
 
     override fun afterConnectionClosed(
@@ -58,13 +44,14 @@ class ChatRoomWebSocketHandler : TextWebSocketHandler() {
         status: CloseStatus,
     ) {
         val chatRoomId = getChatRoomId(session)
-        chatRooms[chatRoomId]?.remove(session)
-        log.debug("User disconnected from chat room: $chatRoomId")
+        messageService.disconnectChatRoom(chatRoomId, session)
+        // TODO : 채팅방 나가기 실패 시 에러 처리
     }
 
     // 채팅방 ID를 URI에서 추출하는 함수
-    private fun getChatRoomId(session: WebSocketSession): String {
+    private fun getChatRoomId(session: WebSocketSession): Long {
         val uri = session.uri.toString()
-        return uri.substringAfterLast("/")
+        return uri.substringAfterLast("/").toLong()
+        // TODO : 채팅방 아이디 얻기 실패 시 에러 처리
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -12,7 +12,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler
 import java.time.LocalDateTime
 
 @Component
-class ChatRoomWebSocketHandler(
+class ChatWebSocketHandler(
     private val messageService: MessageService,
 ) : TextWebSocketHandler() {
     override fun afterConnectionEstablished(session: WebSocketSession) {

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -1,15 +1,14 @@
 package com.friends.chat.websocket
 
 import com.friends.chat.dto.ChatReceiveMessageDto
-import com.friends.chat.dto.ChatSendMessageDto
 import com.friends.common.util.JsonUtil
+import com.friends.message.entity.MessageType
 import com.friends.message.service.MessageService
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
-import java.time.LocalDateTime
 
 @Component
 class ChatWebSocketHandler(
@@ -27,15 +26,12 @@ class ChatWebSocketHandler(
     ) {
         val chatMessage = JsonUtil.fromJson<ChatReceiveMessageDto>(message.payload)
         val chatRoomId = getChatRoomId(session)
-        val chatSendMessageDto =
-            ChatSendMessageDto(
-                senderId = chatMessage.senderId,
-                senderName = chatMessage.senderName,
-                senderProfileImageUrl = chatMessage.senderProfileImageUrl,
-                message = chatMessage.message,
-                sendTime = LocalDateTime.now(),
-            )
-        messageService.sendMessage(chatRoomId, chatSendMessageDto)
+        val memberId = getMemberId(session)
+        /**
+         * 채팅 웹소켓을 통해 보내는 메세지는 TEXT 타입만 있다고 가정합니다.
+         * 이미지의 경우 웹소켓이 아닌 REST API 를 톹ㅇ해 이미지를 업로드하고 이미지 URL 을 채팅방에 보내는 방식으로 구현합니다. // TODO : 채팅방 내에서 이미지 전송하는 API 구현
+         */
+        messageService.sendMessage(chatRoomId, memberId, chatMessage.message, MessageType.TEXT)
         // TODO : 메세지 전송 실패 시 에러 처리
     }
 
@@ -44,7 +40,8 @@ class ChatWebSocketHandler(
         status: CloseStatus,
     ) {
         val chatRoomId = getChatRoomId(session)
-        messageService.disconnectChatRoom(chatRoomId, session)
+        val memberId = getMemberId(session)
+        messageService.disconnectChatRoom(chatRoomId, memberId, session)
         // TODO : 채팅방 나가기 실패 시 에러 처리
     }
 
@@ -54,4 +51,6 @@ class ChatWebSocketHandler(
         return uri.substringAfterLast("/").toLong()
         // TODO : 채팅방 아이디 얻기 실패 시 에러 처리
     }
+
+    private fun getMemberId(session: WebSocketSession): Long = session.attributes["MEMBER_ID"] as Long
 }

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -9,14 +9,20 @@ import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
 
 @Component
 class ChatWebSocketHandler(
     private val messageService: MessageService,
 ) : TextWebSocketHandler() {
+    // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
+    private val chatRooms: MutableMap<Long, MutableSet<WebSocketSession>> = ConcurrentHashMap()
+
     override fun afterConnectionEstablished(session: WebSocketSession) {
         val chatRoomId = getChatRoomId(session)
-        messageService.connectChatRoom(chatRoomId, session)
+        chatRooms.computeIfAbsent(chatRoomId) { CopyOnWriteArraySet() }
+        chatRooms[chatRoomId]?.add(session)
         // TODO : 채팅방 입장 실패 시 에러 처리
     }
 
@@ -31,7 +37,13 @@ class ChatWebSocketHandler(
          * 채팅 웹소켓을 통해 보내는 메세지는 TEXT 타입만 있다고 가정합니다.
          * 이미지의 경우 웹소켓이 아닌 REST API 를 톹ㅇ해 이미지를 업로드하고 이미지 URL 을 채팅방에 보내는 방식으로 구현합니다. // TODO : 채팅방 내에서 이미지 전송하는 API 구현
          */
-        messageService.sendMessage(chatRoomId, memberId, chatMessage.message, MessageType.TEXT)
+        val sendMessageDto = messageService.saveMessage(chatRoomId, memberId, chatMessage.message, MessageType.TEXT)
+        val sessions = chatRooms[chatRoomId]
+        sessions?.forEach { session ->
+            if (session.isOpen) {
+                session.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
+            }
+        }
         // TODO : 메세지 전송 실패 시 에러 처리
     }
 
@@ -41,6 +53,7 @@ class ChatWebSocketHandler(
     ) {
         val chatRoomId = getChatRoomId(session)
         val memberId = getMemberId(session)
+        chatRooms[chatRoomId]?.remove(session) // 세션 제거
         messageService.disconnectChatRoom(chatRoomId, memberId, session)
         // TODO : 채팅방 나가기 실패 시 에러 처리
     }

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebsocketInterceptor.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebsocketInterceptor.kt
@@ -1,0 +1,35 @@
+package com.friends.chat.websocket
+
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.socket.WebSocketHandler
+import org.springframework.web.socket.server.HandshakeInterceptor
+import java.lang.Exception
+
+class ChatWebsocketInterceptor : HandshakeInterceptor {
+    override fun beforeHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        attributes: MutableMap<String, Any>,
+    ): Boolean {
+        /**
+         * WebSocket 연결 요청 시 http 방식으로 handshake 하는 스레드와
+         * WebSocket 연결 이후 메세지를 주고 받는 스레드가 다르기 때문에 SecurityContextHolder에 인증 정보가 없습니다.
+         * 인증 정보를 연결 이후에 사용자 인증 정보를 사용할 수 있도록 WebSocketHandler에서 attributes에 저장합니다.
+         */
+        val memberId = SecurityContextHolder.getContext().authentication.principal as Long
+        attributes["MEMBER_ID"] = memberId
+        return true
+    }
+
+    override fun afterHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        exception: Exception?,
+    ) {
+        // 아무 작업도 필요 없음
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
@@ -1,6 +1,7 @@
 package com.friends.config
 
 import com.friends.chat.websocket.ChatRoomWebSocketHandler
+import com.friends.chat.websocket.ChatWebsocketInterceptor
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.socket.config.annotation.EnableWebSocket
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer
@@ -14,6 +15,7 @@ class WebSocketConfig(
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
         registry
             .addHandler(chatRoomWebSocketHandler, "/ws/chatRoom/{chatRoomId}")
+            .addInterceptors(ChatWebsocketInterceptor())
             .setAllowedOrigins("*") // CORS 허용
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
@@ -1,6 +1,6 @@
 package com.friends.config
 
-import com.friends.chat.websocket.ChatRoomWebSocketHandler
+import com.friends.chat.websocket.ChatWebSocketHandler
 import com.friends.chat.websocket.ChatWebsocketInterceptor
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.socket.config.annotation.EnableWebSocket
@@ -10,11 +10,11 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @Configuration
 @EnableWebSocket
 class WebSocketConfig(
-    private val chatRoomWebSocketHandler: ChatRoomWebSocketHandler,
+    private val chatWebSocketHandler: ChatWebSocketHandler,
 ) : WebSocketConfigurer {
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
         registry
-            .addHandler(chatRoomWebSocketHandler, "/ws/chatRoom/{chatRoomId}")
+            .addHandler(chatWebSocketHandler, "/ws/chatRoom/{chatRoomId}")
             .addInterceptors(ChatWebsocketInterceptor())
             .setAllowedOrigins("*") // CORS 허용
     }

--- a/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
@@ -1,5 +1,6 @@
 package com.friends.message.repository
 
+import com.friends.chat.entity.ChatRoom
 import com.friends.chat.entity.ChatRoomMember
 import com.friends.common.util.getSingle
 import com.friends.message.entity.Message
@@ -11,7 +12,9 @@ import org.springframework.stereotype.Repository
 @Repository
 interface MessageRepository :
     JpaRepository<Message, Long>,
-    MessageCustomRepository
+    MessageCustomRepository {
+    fun findFirstByChatRoomOrderByIdDesc(chatRoom: ChatRoom): Message?
+}
 
 interface MessageCustomRepository {
     fun countUnreadMessages(

--- a/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
@@ -1,8 +1,11 @@
 package com.friends.message.repository
 
+import com.friends.chat.entity.ChatRoom
 import com.friends.message.entity.Message
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface MessageRepository : JpaRepository<Message, Long>
+interface MessageRepository : JpaRepository<Message, Long> {
+    fun findFirstByChatRoomOrderByIdDesc(chatRoom: ChatRoom): Message?
+}

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
@@ -2,6 +2,7 @@ package com.friends.message.service
 
 import com.friends.chat.ChatRoomNotFoundException
 import com.friends.chat.dto.ChatSendMessageDto
+import com.friends.chat.repository.ChatRoomMemberRepository
 import com.friends.chat.repository.ChatRoomRepository
 import com.friends.common.util.JsonUtil
 import com.friends.member.MemberNotFoundException
@@ -20,6 +21,7 @@ class MessageService(
     private val messageRepository: MessageRepository,
     private val memberRepository: MemberRepository,
     private val chatRoomRepository: ChatRoomRepository,
+    private val chatRoomMemberRepository: ChatRoomMemberRepository,
 ) {
     // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
     private val chatRooms: MutableMap<Long, MutableSet<WebSocketSession>> = ConcurrentHashMap()
@@ -34,14 +36,25 @@ class MessageService(
 
     fun disconnectChatRoom(
         chatRoomId: Long,
+        memberId: Long,
         session: WebSocketSession,
     ) {
-        chatRooms[chatRoomId]?.remove(session)
+        chatRooms[chatRoomId]?.remove(session) // 세션 제거
+
+        val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null) ?: return // 채팅방이 없을 경우 무시
+        val member = memberRepository.findById(memberId).orElse(null) ?: return // 멤버가 없을 경우 무시
+        val chatRoomMember = chatRoomMemberRepository.findByChatRoomAndMember(chatRoom, member) ?: return // 채팅방 멤버가 아닐 경우 무시
+
+        // 마지막으로 읽은 메세지 ID 업데이트 (채팅방에 메세지가 없다면 무시)
+        messageRepository.findFirstByChatRoomOrderByIdDesc(chatRoom)?.let {
+            chatRoomMember.lastReadMessageId = it.id
+        }
     }
 
     fun sendMessage(
         chatRoomId: Long,
-        message: ChatSendMessageDto,
+        memberId: Long,
+        message: String,
         type: MessageType,
     ) {
         val sessions = chatRooms[chatRoomId]

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
@@ -74,8 +74,6 @@ class MessageService(
         val sendMessageDto =
             ChatSendMessageDto(
                 senderId = sender.id,
-                senderName = sender.nickname,
-                senderProfileImageUrl = sender.imageUrl ?: "default image url", // TODO : member 와 profile 에 imageUrl 이 중복되어 있는 것을 확인 -> 둘 중 하나로 통일하고 non-null 로 변경 (회원가입 시 주어지지 않는다면 default image url 로 설정)
                 message = savedMessage.content,
                 sendTime = savedMessage.createdAt,
                 type = savedMessage.type,

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
@@ -36,7 +36,7 @@ class MessageService(
 
         // 마지막으로 읽은 메세지 ID 업데이트 (채팅방에 메세지가 없다면 무시)
         messageRepository.findFirstByChatRoomOrderByIdDesc(chatRoom)?.let {
-            chatRoomMember.lastReadMessageId = it.id
+            chatRoomMember.lastReadMessage = it
         }
     }
 

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
@@ -1,0 +1,45 @@
+package com.friends.message.service
+
+import com.friends.chat.dto.ChatSendMessageDto
+import com.friends.common.util.JsonUtil
+import com.friends.member.repository.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
+
+@Service
+class MessageService(
+    private val memberRepository: MemberRepository,
+) {
+    // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
+    private val chatRooms: MutableMap<Long, MutableSet<WebSocketSession>> = ConcurrentHashMap()
+
+    fun connectChatRoom(
+        chatRoomId: Long,
+        session: WebSocketSession,
+    ) {
+        chatRooms.computeIfAbsent(chatRoomId) { CopyOnWriteArraySet() }
+        chatRooms[chatRoomId]?.add(session)
+    }
+
+    fun disconnectChatRoom(
+        chatRoomId: Long,
+        session: WebSocketSession,
+    ) {
+        chatRooms[chatRoomId]?.remove(session)
+    }
+
+    fun sendMessage(
+        chatRoomId: Long,
+        message: ChatSendMessageDto,
+    ) {
+        val sessions = chatRooms[chatRoomId]
+        sessions?.forEach { session ->
+            if (session.isOpen) {
+                session.sendMessage(TextMessage(JsonUtil.toJson(message)))
+            }
+        }
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
@@ -4,17 +4,14 @@ import com.friends.chat.ChatRoomNotFoundException
 import com.friends.chat.dto.ChatSendMessageDto
 import com.friends.chat.repository.ChatRoomMemberRepository
 import com.friends.chat.repository.ChatRoomRepository
-import com.friends.common.util.JsonUtil
 import com.friends.member.MemberNotFoundException
 import com.friends.member.repository.MemberRepository
 import com.friends.message.entity.Message
 import com.friends.message.entity.MessageType
 import com.friends.message.repository.MessageRepository
 import org.springframework.stereotype.Service
-import org.springframework.web.socket.TextMessage
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.socket.WebSocketSession
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArraySet
 
 @Service
 class MessageService(
@@ -23,24 +20,16 @@ class MessageService(
     private val chatRoomRepository: ChatRoomRepository,
     private val chatRoomMemberRepository: ChatRoomMemberRepository,
 ) {
-    // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
-    private val chatRooms: MutableMap<Long, MutableSet<WebSocketSession>> = ConcurrentHashMap()
-
-    fun connectChatRoom(
-        chatRoomId: Long,
-        session: WebSocketSession,
-    ) {
-        chatRooms.computeIfAbsent(chatRoomId) { CopyOnWriteArraySet() }
-        chatRooms[chatRoomId]?.add(session)
-    }
-
+    /**
+     * 채팅방을 나갈 때마다 마지막으로 읽은 메세지 ID를 업데이트합니다.
+     * 채팅방이 없거나 멤버가 없거나 채팅방 멤버가 아닐 경우 무시합니다.
+     */
+    @Transactional
     fun disconnectChatRoom(
         chatRoomId: Long,
         memberId: Long,
         session: WebSocketSession,
     ) {
-        chatRooms[chatRoomId]?.remove(session) // 세션 제거
-
         val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null) ?: return // 채팅방이 없을 경우 무시
         val member = memberRepository.findById(memberId).orElse(null) ?: return // 멤버가 없을 경우 무시
         val chatRoomMember = chatRoomMemberRepository.findByChatRoomAndMember(chatRoom, member) ?: return // 채팅방 멤버가 아닐 경우 무시
@@ -51,14 +40,17 @@ class MessageService(
         }
     }
 
-    fun sendMessage(
+    /**
+     * 채팅방에 메세지를 보낼 메세지를 저장합니다.
+     * 채팅방이 없거나 멤버가 없을 경우 예외를 발생시킵니다.
+     */
+    @Transactional
+    fun saveMessage(
         chatRoomId: Long,
         memberId: Long,
         message: String,
         type: MessageType,
-    ) {
-        val sessions = chatRooms[chatRoomId]
-
+    ): ChatSendMessageDto {
         /**
          * 메세지를 보낼 때마다 보낸 유저와 채팅방이 있는지 DB 에 확인합니다.
          * 이 과정이 비효율적일 경우 아래 프록시 객체를 생성하여 메세지를 보내는 로직을 고려합니다.
@@ -71,17 +63,11 @@ class MessageService(
         val sender = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
 
         val savedMessage = messageRepository.save(Message.of(chatRoom, sender, message, type))
-        val sendMessageDto =
-            ChatSendMessageDto(
-                senderId = sender.id,
-                message = savedMessage.content,
-                sendTime = savedMessage.createdAt,
-                type = savedMessage.type,
-            )
-        sessions?.forEach { session ->
-            if (session.isOpen) {
-                session.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
-            }
-        }
+        return ChatSendMessageDto(
+            senderId = sender.id,
+            message = savedMessage.content,
+            sendTime = savedMessage.createdAt,
+            type = savedMessage.type,
+        )
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
@@ -1,8 +1,14 @@
 package com.friends.message.service
 
+import com.friends.chat.ChatRoomNotFoundException
 import com.friends.chat.dto.ChatSendMessageDto
+import com.friends.chat.repository.ChatRoomRepository
 import com.friends.common.util.JsonUtil
+import com.friends.member.MemberNotFoundException
 import com.friends.member.repository.MemberRepository
+import com.friends.message.entity.Message
+import com.friends.message.entity.MessageType
+import com.friends.message.repository.MessageRepository
 import org.springframework.stereotype.Service
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
@@ -11,7 +17,9 @@ import java.util.concurrent.CopyOnWriteArraySet
 
 @Service
 class MessageService(
+    private val messageRepository: MessageRepository,
     private val memberRepository: MemberRepository,
+    private val chatRoomRepository: ChatRoomRepository,
 ) {
     // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
     private val chatRooms: MutableMap<Long, MutableSet<WebSocketSession>> = ConcurrentHashMap()
@@ -34,11 +42,34 @@ class MessageService(
     fun sendMessage(
         chatRoomId: Long,
         message: ChatSendMessageDto,
+        type: MessageType,
     ) {
         val sessions = chatRooms[chatRoomId]
+
+        /**
+         * 메세지를 보낼 때마다 보낸 유저와 채팅방이 있는지 DB 에 확인합니다.
+         * 이 과정이 비효율적일 경우 아래 프록시 객체를 생성하여 메세지를 보내는 로직을 고려합니다.
+         * 프록시 객체는 DB 에서 채팅방과 유저 정보를 요청하지 않지만, DB 에 데이터가 있는지 없는지 확인할 수 없습니다.
+         *
+         * val chatRoom = entityManager.getReference(ChatRoom::class.java, chatRoomId)
+         * val sender = entityManager.getReference(Member::class.java, message.senderId)
+         */
+        val chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow { ChatRoomNotFoundException() }
+        val sender = memberRepository.findById(message.senderId).orElseThrow { MemberNotFoundException() }
+
+        val savedMessage = messageRepository.save(Message.of(chatRoom, sender, message.message, type))
+        val sendMessageDto =
+            ChatSendMessageDto(
+                senderId = sender.id,
+                senderName = sender.nickname,
+                senderProfileImageUrl = sender.imageUrl ?: "default image url", // TODO : member 와 profile 에 imageUrl 이 중복되어 있는 것을 확인 -> 둘 중 하나로 통일하고 non-null 로 변경 (회원가입 시 주어지지 않는다면 default image url 로 설정)
+                message = savedMessage.content,
+                sendTime = savedMessage.createdAt,
+                type = savedMessage.type,
+            )
         sessions?.forEach { session ->
             if (session.isOpen) {
-                session.sendMessage(TextMessage(JsonUtil.toJson(message)))
+                session.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
             }
         }
     }

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageService.kt
@@ -68,9 +68,9 @@ class MessageService(
          * val sender = entityManager.getReference(Member::class.java, message.senderId)
          */
         val chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow { ChatRoomNotFoundException() }
-        val sender = memberRepository.findById(message.senderId).orElseThrow { MemberNotFoundException() }
+        val sender = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
 
-        val savedMessage = messageRepository.save(Message.of(chatRoom, sender, message.message, type))
+        val savedMessage = messageRepository.save(Message.of(chatRoom, sender, message, type))
         val sendMessageDto =
             ChatSendMessageDto(
                 senderId = sender.id,


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] 메세지 서비스 객체를 구현하였습니다.
  - 메세지를 전송하면 메세지가 message 테이블 에 저장됩니다.
  - 웹소켓이 끊어지면 chat_room_member 테이블 의 마지막으로 읽은 메세지의 id 가 갱신됩니다. 
- [ ] 웹소켓 인터셉터를 구현하여 웹소켓이 연결될 때 Security Context 에서 유저 id 를 받을 수 있도록 설정하였습니다.

### 🔗 관련 이슈
- #64 

### 💬 기타 참고 사항
- 테스트 코드를 짜볼려고 했는데, 웹소켓을 사용하는 부분이 있어서 쉽지 않더라구요..
  postman 에서 웹소켓을 연결해서 테스트를 해봤는데, 실시간 양방향 채팅이 잘되고 메세지도 잘 저장되며 웹소켓이 끊어질 때 마지막으로 읽은 메세지도 잘 갱신하는 것을 확인하였습니다 👍 
