### PR TITLE
Feature/read message controller

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
@@ -23,6 +23,11 @@ interface ChatRoomMemberRepository :
         chatRoom: ChatRoom,
         member: Member,
     ): ChatRoomMember?
+
+    fun existsChatRoomMemberByChatRoomAndMember(
+        chatRoom: ChatRoom,
+        member: Member,
+    ): Boolean
 }
 
 interface ChatRoomMemberCustomRepository {

--- a/friends_server/src/main/kotlin/com/friends/message/controller/MessageController.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/controller/MessageController.kt
@@ -1,0 +1,39 @@
+package com.friends.message.controller
+
+import com.friends.common.dto.ListBaseResponse
+import com.friends.common.dto.SliceBaseResponse
+import com.friends.message.dto.MessageResponseDto
+import com.friends.message.service.MessageQueryService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/user/message")
+class MessageController(
+    private val messageQueryService: MessageQueryService,
+) {
+    @GetMapping("/unread/{chatRoomId}")
+    fun getUnreadMessageCount(
+        @AuthenticationPrincipal memberId: Long,
+        @PathVariable chatRoomId: Long,
+    ): ResponseEntity<ListBaseResponse<MessageResponseDto>> {
+        val result = messageQueryService.getUnreadMessage(memberId, chatRoomId)
+        return ResponseEntity.ok(result)
+    }
+
+    @GetMapping("/previous/{chatRoomId}")
+    fun getPreviousMessage(
+        @AuthenticationPrincipal memberId: Long,
+        @PathVariable chatRoomId: Long,
+        @RequestParam("size", defaultValue = "20") size: Int,
+        @RequestParam("lastMessageId", required = false) lastMessageId: Long?,
+    ): ResponseEntity<SliceBaseResponse<MessageResponseDto>> {
+        val result = messageQueryService.getPreviousMessages(chatRoomId, memberId, lastMessageId, size)
+        return ResponseEntity.ok(result)
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/message/controller/MessageController.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/controller/MessageController.kt
@@ -16,9 +16,9 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/user/message")
 class MessageController(
     private val messageQueryService: MessageQueryService,
-) {
+) : MessageControllerSpec {
     @GetMapping("/unread/{chatRoomId}")
-    fun getUnreadMessageCount(
+    override fun getUnreadMessages(
         @AuthenticationPrincipal memberId: Long,
         @PathVariable chatRoomId: Long,
     ): ResponseEntity<ListBaseResponse<MessageResponseDto>> {
@@ -27,7 +27,7 @@ class MessageController(
     }
 
     @GetMapping("/previous/{chatRoomId}")
-    fun getPreviousMessage(
+    override fun getPreviousMessage(
         @AuthenticationPrincipal memberId: Long,
         @PathVariable chatRoomId: Long,
         @RequestParam("size", defaultValue = "20") size: Int,

--- a/friends_server/src/main/kotlin/com/friends/message/controller/MessageControllerSpec.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/controller/MessageControllerSpec.kt
@@ -1,0 +1,62 @@
+package com.friends.message.controller
+
+import com.friends.common.dto.ListBaseResponse
+import com.friends.common.dto.SliceBaseResponse
+import com.friends.common.exception.ErrorCode
+import com.friends.common.swagger.ApiErrorCodeExamples
+import com.friends.message.dto.MessageResponseDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+
+@Tag(name = "Message")
+interface MessageControllerSpec {
+    @Operation(
+        description =
+            "읽지 않은 메세지 조회 API <br>" +
+                "로그인 된 사용자만 사용 가능합니다",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "읽지 않은 메세지 조회 성공",
+            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.NOT_FOUND_MEMBER,
+            ErrorCode.CHAT_ROOM_NOT_FOUND,
+            ErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND,
+        ],
+    )
+    fun getUnreadMessages(
+        memberId: Long,
+        chatRoomId: Long,
+    ): ResponseEntity<ListBaseResponse<MessageResponseDto>>
+
+    @Operation(
+        description =
+            "이전 메세지 조회 API <br>" +
+                "로그인 된 사용자만 사용 가능합니다",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "이전 메세지 조회 성공",
+            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.NOT_FOUND_MEMBER,
+            ErrorCode.CHAT_ROOM_NOT_FOUND,
+            ErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND,
+        ],
+    )
+    fun getPreviousMessage(
+        memberId: Long,
+        chatRoomId: Long,
+        size: Int,
+        lastMessageId: Long?,
+    ): ResponseEntity<SliceBaseResponse<MessageResponseDto>>
+}

--- a/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
@@ -10,6 +10,7 @@ import com.friends.message.entity.MessageType
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
@@ -73,7 +74,7 @@ class MessageCustomRepositoryImpl(
 
     /**
      * 채팅방의 특정 메세지 이전의 메세지를 가져옵니다.
-     * id 내림차순으로 정렬합니다.
+     * id 오름차순으로 정렬합니다.
      */
     override fun findMessagesBeforeIdInChatRoom(
         chatRoom: ChatRoom,
@@ -81,15 +82,20 @@ class MessageCustomRepositoryImpl(
         size: Int,
     ): Slice<Message> {
         val pageable = Pageable.ofSize(size)
-        return kotlinJdslJpqlExecutor.getSlice(pageable) {
-            select(entity(Message::class))
-                .from(entity(Message::class))
-                .where(
-                    and(
-                        path(Message::chatRoom).equal(chatRoom),
-                        messageId?.let { path(Message::id).lessThan(it) },
-                    ),
-                ).orderBy(path(Message::id).desc())
-        }
+        val slice =
+            kotlinJdslJpqlExecutor.getSlice(pageable) {
+                select(entity(Message::class))
+                    .from(entity(Message::class))
+                    .where(
+                        and(
+                            path(Message::chatRoom).equal(chatRoom),
+                            messageId?.let { path(Message::id).lessThan(it) },
+                        ),
+                    ).orderBy(path(Message::id).desc()) // 여전히 내림차순으로 정렬
+            }
+
+        // 결과를 오름차순으로 변환
+        val sortedContent = slice.content.reversed()
+        return SliceImpl(sortedContent, pageable, slice.hasNext())
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageQueryService.kt
@@ -29,6 +29,7 @@ class MessageQueryService(
     ): ListBaseResponse<MessageResponseDto> {
         val member = memberRepository.findById(memberId).orElse(null) ?: throw MemberNotFoundException()
         val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null) ?: throw ChatRoomNotFoundException()
+        // 채팅방에 속한 멤버인지 확인하는 유효성 검사도 같이 수행합니다.
         val chatRoomMember = chatRoomMemberRepository.findByChatRoomAndMember(chatRoom, member) ?: throw ChatRoomMemberNotFoundException()
 
         val messages = messageRepository.findUnreadMessagesForMember(chatRoomMember).map { toMessageResponseDto(it) }
@@ -37,10 +38,17 @@ class MessageQueryService(
 
     fun getPreviousMessages(
         chatRoomId: Long,
-        messageId: Long,
+        memberId: Long,
+        messageId: Long?,
         size: Int,
     ): SliceBaseResponse<MessageResponseDto> {
         val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null) ?: throw ChatRoomNotFoundException()
+        val member = memberRepository.findById(memberId).orElse(null) ?: throw MemberNotFoundException()
+
+        // 채팅방에 속한 멤버인지 확인합니다.
+        if (!chatRoomMemberRepository.existsChatRoomMemberByChatRoomAndMember(chatRoom, member)) {
+            throw ChatRoomMemberNotFoundException()
+        }
 
         /**
          * 이전 메세지를 들을 가져와 역순으로 반환합니다.

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageQueryService.kt
@@ -56,7 +56,6 @@ class MessageQueryService(
          * 하지만 클라이언트에서는 message id 를 오름차순으로 정렬하여 보여주기 때문에 역순으로 반환합니다.
          */
         val messages = messageRepository.findMessagesBeforeIdInChatRoom(chatRoom, messageId, size).map { toMessageResponseDto(it) }
-        messages.content.reverse()
         return toSliceBaseResponse(messages)
     }
 }


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] 메세지 조회 컨트롤러를 작성하였습니다.
- [ ] 메세지를 조회할 때 채팅방에 참여하지 않은 유저라면 에러가 나도록 설정하였습니다.
- [ ] 이전 메세지를 조회할 때 sql 에서 메세지의 id 로 내림차순하여 limit 쿼리를 날려야 하는데, 클라이언트에서 보여지는 메세지 리스트는 id 기준 오름 차순이므로 이를 정렬하는 로직을 수정하였습니다.
 이때 조회 결과를 `reverse` 하였는데 sql 조회 결과 리스트가 `UnmodifiableList` 로 수정이 불가능하여 새롭게 `MutableList` 만든 뒤 재정렬하였습니다.

### 🔗 관련 이슈
- #105 

### 💬 기타 참고 사항
- 
