### PR TITLE
Feature/validate websocket with seconday token

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -60,7 +60,7 @@ class ChatWebSocketHandler(
 
     // 채팅방 ID를 URI에서 추출하는 함수
     private fun getChatRoomId(session: WebSocketSession): Long {
-        val uri = session.uri.toString()
+        val uri = session.uri.toString().split("?")[0]
         return uri.substringAfterLast("/").toLong()
         // TODO : 채팅방 아이디 얻기 실패 시 에러 처리
     }

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebsocketInterceptor.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebsocketInterceptor.kt
@@ -1,13 +1,18 @@
 package com.friends.chat.websocket
 
+import com.friends.secondaryToken.SecondaryTokenService
 import org.springframework.http.server.ServerHttpRequest
 import org.springframework.http.server.ServerHttpResponse
-import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.http.server.ServletServerHttpRequest
+import org.springframework.stereotype.Component
 import org.springframework.web.socket.WebSocketHandler
 import org.springframework.web.socket.server.HandshakeInterceptor
 import java.lang.Exception
 
-class ChatWebsocketInterceptor : HandshakeInterceptor {
+@Component
+class ChatWebsocketInterceptor(
+    private val secondaryTokenService: SecondaryTokenService,
+) : HandshakeInterceptor {
     override fun beforeHandshake(
         request: ServerHttpRequest,
         response: ServerHttpResponse,
@@ -19,7 +24,9 @@ class ChatWebsocketInterceptor : HandshakeInterceptor {
          * WebSocket 연결 이후 메세지를 주고 받는 스레드가 다르기 때문에 SecurityContextHolder에 인증 정보가 없습니다.
          * 인증 정보를 연결 이후에 사용자 인증 정보를 사용할 수 있도록 WebSocketHandler에서 attributes에 저장합니다.
          */
-        val memberId = SecurityContextHolder.getContext().authentication.principal as Long
+        val queryParams = (request as ServletServerHttpRequest).servletRequest.parameterMap
+        val token = queryParams["token"]?.firstOrNull() ?: throw IllegalArgumentException("Token is required")
+        val memberId = secondaryTokenService.getMemberId(token)
         attributes["MEMBER_ID"] = memberId
         return true
     }

--- a/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
@@ -48,8 +48,9 @@ class SpringSecurityConfig(
                     "/api/global/**",
                     "/swagger-ui/**",
                     "/v3/api-docs/**",
+                    "ws/chatRoom/**",
                 ).permitAll()
-                .requestMatchers("/api/user/**", "ws/chatRoom/**")
+                .requestMatchers("/api/user/**")
                 .hasAuthority(Role.ROLE_USER.name)
                 .requestMatchers("/api/admin/**")
                 .hasAuthority(Role.ROLE_ADMIN.name)

--- a/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
@@ -11,11 +11,12 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @EnableWebSocket
 class WebSocketConfig(
     private val chatWebSocketHandler: ChatWebSocketHandler,
+    private val chatWebsocketInterceptor: ChatWebsocketInterceptor,
 ) : WebSocketConfigurer {
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
         registry
             .addHandler(chatWebSocketHandler, "/ws/chatRoom/{chatRoomId}")
-            .addInterceptors(ChatWebsocketInterceptor())
+            .addInterceptors(chatWebsocketInterceptor)
             .setAllowedOrigins("*") // CORS 허용
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenController.kt
+++ b/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenController.kt
@@ -1,0 +1,21 @@
+package com.friends.secondaryToken
+
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/user")
+@RestController
+class SecondaryTokenController(
+    private val secondaryTokenService: SecondaryTokenService,
+) {
+    @GetMapping("/secondaryToken")
+    fun getSecondaryToken(
+        @AuthenticationPrincipal memberId: Long,
+    ): ResponseEntity<SecondaryTokenResponseDto> {
+        val secondaryToken = secondaryTokenService.createAndSaveSecondaryToken(memberId)
+        return ResponseEntity.ok(SecondaryTokenResponseDto(secondaryToken))
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenController.kt
+++ b/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenController.kt
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class SecondaryTokenController(
     private val secondaryTokenService: SecondaryTokenService,
-) {
+) : SecondaryTokenControllerSpec {
     @GetMapping("/secondaryToken")
-    fun getSecondaryToken(
+    override fun getSecondaryToken(
         @AuthenticationPrincipal memberId: Long,
     ): ResponseEntity<SecondaryTokenResponseDto> {
         val secondaryToken = secondaryTokenService.createAndSaveSecondaryToken(memberId)

--- a/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenControllerSpec.kt
+++ b/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenControllerSpec.kt
@@ -1,0 +1,27 @@
+package com.friends.secondaryToken
+
+import com.friends.common.exception.ErrorCode
+import com.friends.common.swagger.ApiErrorCodeExamples
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+
+@Tag(name = "Secondary Token")
+interface SecondaryTokenControllerSpec {
+    @Operation(
+        description = "Secondary Token 발급 API",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Secondary Token 발급 성공",
+            ),
+        ],
+    )
+    @ApiErrorCodeExamples(
+        [
+            ErrorCode.UNAUTHORIZED,
+        ],
+    )
+    fun getSecondaryToken(memberId: Long): ResponseEntity<SecondaryTokenResponseDto>
+}

--- a/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenDtos.kt
+++ b/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenDtos.kt
@@ -1,0 +1,5 @@
+package com.friends.secondaryToken
+
+data class SecondaryTokenResponseDto(
+    val secondaryToken: String,
+)

--- a/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenRepository.kt
@@ -1,0 +1,24 @@
+package com.friends.secondaryToken
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+import java.util.concurrent.TimeUnit
+
+@Repository
+class SecondaryTokenRepository(
+    private val redisTemplate: RedisTemplate<String, Long>,
+) {
+    private fun getKey(token: String) = "secondaryToken:$token"
+
+    fun save(
+        token: String,
+        memberId: Long,
+        expiration: Long,
+    ) {
+        redisTemplate.opsForValue().set(getKey(token), memberId, expiration, TimeUnit.SECONDS)
+    }
+
+    fun getMemberId(token: String): Long? = redisTemplate.opsForValue().get(getKey(token))
+
+    fun delete(token: String) = redisTemplate.delete(getKey(token))
+}

--- a/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenRepository.kt
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 
 @Repository
 class SecondaryTokenRepository(
-    private val redisTemplate: RedisTemplate<String, Long>,
+    private val redisTemplate: RedisTemplate<String, String>,
 ) {
     private fun getKey(token: String) = "secondaryToken:$token"
 
@@ -15,10 +15,10 @@ class SecondaryTokenRepository(
         memberId: Long,
         expiration: Long,
     ) {
-        redisTemplate.opsForValue().set(getKey(token), memberId, expiration, TimeUnit.SECONDS)
+        redisTemplate.opsForValue().set(getKey(token), memberId.toString(), expiration, TimeUnit.SECONDS)
     }
 
-    fun getMemberId(token: String): Long? = redisTemplate.opsForValue().get(getKey(token))
+    fun getMemberId(token: String): Long? = redisTemplate.opsForValue().get(getKey(token))?.toLong()
 
     fun delete(token: String) = redisTemplate.delete(getKey(token))
 }

--- a/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenService.kt
+++ b/friends_server/src/main/kotlin/com/friends/secondaryToken/SecondaryTokenService.kt
@@ -1,0 +1,41 @@
+package com.friends.secondaryToken
+
+import com.friends.security.securityException.InvalidTokenException
+import org.springframework.stereotype.Service
+import java.security.SecureRandom
+import java.util.Base64
+
+@Service
+class SecondaryTokenService(
+    private val secondaryTokenRepository: SecondaryTokenRepository,
+) {
+    /**
+     * memberId를 통해 code를 생성하고 저장합니다.
+     * code 의 유효시간은 5분입니다.
+     */
+    fun createAndSaveSecondaryToken(
+        memberId: Long,
+    ): String {
+        val code = createRandomToken(32)
+        secondaryTokenRepository.save(code, memberId, 300)
+        return code
+    }
+
+    /**
+     * code를 통해 memberId를 가져옵니다.
+     * code는 한 번만 사용할 수 있습니다.
+     */
+    fun getMemberId(code: String): Long {
+        secondaryTokenRepository.getMemberId(code)?.let {
+            secondaryTokenRepository.delete(code)
+            return it
+        } ?: throw InvalidTokenException()
+    }
+
+    private fun createRandomToken(length: Int): String {
+        val random = SecureRandom() // 안전한 난수를 생성합니다.
+        val bytes = ByteArray(length) // 길이만큼의 바이트 배열을 생성합니다.
+        random.nextBytes(bytes) // 바이트 배열에 난수를 채웁니다.
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes) // 바이트 배열을 Base64로 url-safe하게 인코딩합니다.
+    }
+}


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] 웹소켓을 글로벌 권한으로 전환하였습니다.
- [ ] 웹소켓 연결 인증을 url 파라미터로 받는 token 을 통해 진행하였습니다.
- [ ] 인증된 사용자에게 일회용 secondary token 을 발행하고 이 토큰의 유효성을 검사하는 서비스를 작성하였습니다.

### 🔗 관련 이슈
- 

### 💬 기타 참고 사항
- 

