### PR TITLE
Feature/change websocket connection to single

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
@@ -7,10 +7,12 @@ import java.time.LocalDateTime
  * 채팅 웹소켓에서 메세지 전송은 로그인된 유저만 이용할 수 있기 때문에 senderId는 SecurityContextHolder에서 가져옵니다.
  */
 data class ChatReceiveMessageDto(
+    val chatRoomId: Long,
     val message: String,
 )
 
 data class ChatSendMessageDto(
+    val chatRoomId: Long,
     val senderId: Long,
     val message: String,
     val sendTime: LocalDateTime,

--- a/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
@@ -19,6 +19,8 @@ interface ChatRoomMemberRepository :
     ChatRoomMemberCustomRepository {
     fun countByChatRoom(chatRoom: ChatRoom): Int
 
+    fun findAllByMemberId(memberId: Long): List<ChatRoomMember>
+
     fun findByChatRoomAndMember(
         chatRoom: ChatRoom,
         member: Member,

--- a/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
@@ -30,8 +30,6 @@ interface ChatRoomMemberRepository :
         chatRoom: ChatRoom,
         member: Member,
     ): Boolean
-
-    fun findAllByMemberId(memberId: Long): List<ChatRoomMember>
 }
 
 interface ChatRoomMemberCustomRepository {

--- a/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
@@ -28,6 +28,8 @@ interface ChatRoomMemberRepository :
         chatRoom: ChatRoom,
         member: Member,
     ): Boolean
+
+    fun findAllByMemberId(memberId: Long): List<ChatRoomMember>
 }
 
 interface ChatRoomMemberCustomRepository {

--- a/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomCommandService.kt
@@ -44,7 +44,7 @@ class ChatRoomCommandService(
         val member = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
         val chatRoom = chatRoomRepository.save(ChatRoom.of(request.title, member, imageUrl))
         chatRoomCategoryRepository.saveAll(categoryRepository.findByIdIn(request.categoryIdList).also { if (it.isEmpty()) throw ChatRoomCategoryNotFoundException() }.map { ChatRoomCategory.of(chatRoom, it) })
-        val enterMassage = messageCommandService.sendMessage(chatRoom.id, member.id, Message.enterMessage(member.nickname), MessageType.TEXT)
+        val enterMassage = messageCommandService.sendMessage(chatRoom.id, member.id, Message.enterMessage(member.nickname), MessageType.SYSTEM)
         chatRoomMemberRepository.save(ChatRoomMember.of(chatRoom, member, enterMassage))
         return CreateChatRoomResponseDto(chatRoom.id)
     }
@@ -57,7 +57,7 @@ class ChatRoomCommandService(
         val chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow { ChatRoomNotFoundException() }
         val member = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
         if (!chatRoomMemberRepository.existsChatRoomMemberByChatRoomAndMember(chatRoom, member)) {
-            val enterMessage = messageCommandService.sendMessage(chatRoom.id, member.id, Message.enterMessage(member.nickname), MessageType.TEXT)
+            val enterMessage = messageCommandService.sendMessage(chatRoom.id, member.id, Message.enterMessage(member.nickname), MessageType.SYSTEM)
             chatRoomMemberRepository.save(ChatRoomMember.of(chatRoom, member, enterMessage))
         }
     }

--- a/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomCommandService.kt
@@ -11,12 +11,12 @@ import com.friends.chat.entity.ChatRoomMember
 import com.friends.chat.repository.ChatRoomCategoryRepository
 import com.friends.chat.repository.ChatRoomMemberRepository
 import com.friends.chat.repository.ChatRoomRepository
-import com.friends.chat.websocket.ChatWebSocketHandler
 import com.friends.image.S3ClientService
 import com.friends.member.MemberNotFoundException
 import com.friends.member.repository.MemberRepository
 import com.friends.message.entity.Message
-import com.friends.message.repository.MessageRepository
+import com.friends.message.entity.MessageType
+import com.friends.message.service.MessageCommandService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -28,9 +28,8 @@ class ChatRoomCommandService(
     private val memberRepository: MemberRepository,
     private val categoryRepository: CategoryRepository,
     private val chatRoomCategoryRepository: ChatRoomCategoryRepository,
-    private val messageRepository: MessageRepository,
     private val s3ClientService: S3ClientService,
-    private val chatWebSocketHandler: ChatWebSocketHandler,
+    private val messageCommandService: MessageCommandService,
 ) {
     @Transactional
     fun createChatRoom(
@@ -45,7 +44,7 @@ class ChatRoomCommandService(
         val member = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
         val chatRoom = chatRoomRepository.save(ChatRoom.of(request.title, member, imageUrl))
         chatRoomCategoryRepository.saveAll(categoryRepository.findByIdIn(request.categoryIdList).also { if (it.isEmpty()) throw ChatRoomCategoryNotFoundException() }.map { ChatRoomCategory.of(chatRoom, it) })
-        val enterMassage = messageRepository.save(Message.createEnterMessage(member, chatRoom))
+        val enterMassage = messageCommandService.sendMessage(chatRoom.id, member.id, Message.enterMessage(member.nickname), MessageType.TEXT)
         chatRoomMemberRepository.save(ChatRoomMember.of(chatRoom, member, enterMassage))
         return CreateChatRoomResponseDto(chatRoom.id)
     }
@@ -58,9 +57,8 @@ class ChatRoomCommandService(
         val chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow { ChatRoomNotFoundException() }
         val member = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
         if (!chatRoomMemberRepository.existsChatRoomMemberByChatRoomAndMember(chatRoom, member)) {
-            val enterMessage = messageRepository.save(Message.createEnterMessage(member, chatRoom))
+            val enterMessage = messageCommandService.sendMessage(chatRoom.id, member.id, Message.enterMessage(member.nickname), MessageType.TEXT)
             chatRoomMemberRepository.save(ChatRoomMember.of(chatRoom, member, enterMessage))
-            chatWebSocketHandler.sendMessage(chatRoomId, enterMessage)
         }
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -20,7 +20,7 @@ class ChatWebSocketHandler(
     // 채팅방 ID를 키로 하고, 참여하고 있는 member의 id를 value로 하는 Map
     private val connectedParticipants = ConcurrentHashMap<Long, MutableSet<Long>>()
     // memberId 를 키로 하고, WebSocketSession을 value로 하는 Map
-    private val sessions = ConcurrentHashMap<Long, WebSocketSession>()
+    private val sessions = ConcurrentHashMap<Long, MutableSet<WebSocketSession>>()
 
     private fun addParticipant(
         chatRoomId: Long,
@@ -39,12 +39,30 @@ class ChatWebSocketHandler(
         connectedParticipants[chatRoomId]?.remove(memberId)
     }
 
+    private fun addSession(
+        memberId: Long,
+        session: WebSocketSession,
+    ) {
+        val userSessions =
+            sessions.computeIfAbsent(memberId) {
+                ConcurrentHashMap.newKeySet()
+            }
+        userSessions.add(session)
+    }
+
+    private fun removeSession(
+        memberId: Long,
+        session: WebSocketSession,
+    ) {
+        sessions[memberId]?.remove(session)
+    }
+
     override fun afterConnectionEstablished(session: WebSocketSession) {
         /**
          * 웹소켓 연결 후 메세지를 수신받기 위해 sessions Map 에 저장합니다.
          */
         val memberId = getMemberId(session)
-        sessions.putIfAbsent(memberId, session)
+        addSession(memberId, session)
 
         /**
          * 메세지를 수신할 채팅방(참여중인 모든 채팅방)을 추가합니다.
@@ -68,10 +86,12 @@ class ChatWebSocketHandler(
          */
         val sendMessageDto = messageCommandService.saveMessage(chatRoomId, memberId, chatMessage.message, MessageType.TEXT)
         /**
-         * 채팅방에 참여하고 있는 모든 유저에게 메세지를 전송합니다.
+         * 채팅방에 참여하고 있는 모든 유저의 디바이스에 메세지를 전송합니다.
          */
         connectedParticipants[chatRoomId]?.forEach { participantId ->
-            sessions[participantId]?.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
+            sessions[participantId]?.forEach { participantSession ->
+                participantSession.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
+            }
         }
         // TODO : 메세지 전송 실패 시 에러 처리
     }
@@ -84,7 +104,7 @@ class ChatWebSocketHandler(
          * 웹소켓 연결 종료 후 sessions Map 에서 제거합니다.
          */
         val memberId = getMemberId(session)
-        sessions.remove(memberId)
+        removeSession(memberId, session)
         /**
          * 메세지를 수신하지 않도록 연결된 채팅방을 제거합니다.
          */

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -16,8 +16,10 @@ import java.util.concurrent.CopyOnWriteArraySet
 class ChatWebSocketHandler(
     private val messageCommandService: MessageCommandService,
 ) : TextWebSocketHandler() {
-    // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
-    private val chatRooms: MutableMap<Long, MutableSet<WebSocketSession>> = ConcurrentHashMap()
+    // 채팅방 ID를 키로 하고, 참여하고 있는 member의 id를 value로 하는 Map
+    private val participants = ConcurrentHashMap<Long, MutableSet<Long>>()
+    // memberId 를 키로 하고, WebSocketSession을 value로 하는 Map
+    private val sessions = ConcurrentHashMap<Long, WebSocketSession>()
 
     override fun afterConnectionEstablished(session: WebSocketSession) {
         val chatRoomId = getChatRoomId(session)

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -2,9 +2,7 @@ package com.friends.chat.websocket
 
 import com.friends.chat.UnexpectedChatRoomException
 import com.friends.chat.dto.ChatReceiveMessageDto
-import com.friends.chat.dto.ChatSendMessageDto
 import com.friends.common.util.JsonUtil
-import com.friends.message.entity.Message
 import com.friends.message.entity.MessageType
 import com.friends.message.service.MessageCommandService
 import org.springframework.stereotype.Component
@@ -12,24 +10,15 @@ import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArraySet
-import java.util.concurrent.ExecutorService
 
 @Component
 class ChatWebSocketHandler(
     private val messageCommandService: MessageCommandService,
-    private val executor: ExecutorService,
 ) : TextWebSocketHandler() {
-    // 채팅방 ID를 키로 하고, 각 채팅방의 세션을 Set으로 저장
-    private val chatRooms: MutableMap<Long, MutableSet<WebSocketSession>> = ConcurrentHashMap()
-
     override fun afterConnectionEstablished(session: WebSocketSession) {
         try {
-            val chatRoomId = getChatRoomId(session)
-            chatRooms.computeIfAbsent(chatRoomId) { CopyOnWriteArraySet() }
-            chatRooms[chatRoomId]?.add(session)
+            val memberId = getMemberId(session)
+            messageCommandService.addOnlineUser(memberId, session)
         } catch (e: Exception) {
             session.close(CloseStatus.SERVER_ERROR)// 채팅방 연결 종료 후 에러 처리
             throw UnexpectedChatRoomException(e)
@@ -41,60 +30,30 @@ class ChatWebSocketHandler(
         message: TextMessage,
     ) {
         val chatMessage = JsonUtil.fromJson<ChatReceiveMessageDto>(message.payload)
-        val chatRoomId = getChatRoomId(session)
         val memberId = getMemberId(session)
         /**
          * 채팅 웹소켓을 통해 보내는 메세지는 TEXT 타입만 있다고 가정합니다.
          * 이미지의 경우 웹소켓이 아닌 REST API 를 통해 이미지를 업로드하고 이미지 URL 을 채팅방에 보내는 방식으로 구현합니다. // TODO : 채팅방 내에서 이미지 전송하는 API 구현
          */
-        val sendMessageDto = messageCommandService.saveMessage(chatRoomId, memberId, chatMessage.message, MessageType.TEXT)
-        val sessions = chatRooms[chatRoomId]
-        sessions?.forEach { session ->
-            if (session.isOpen) {
-                session.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
-            }
-        }
+        messageCommandService.sendMessage(
+            chatMessage.chatRoomId,
+            memberId,
+            chatMessage.message,
+            MessageType.TEXT,
+        )
         // TODO : 아래 내용 리뷰 받고 수정
-    }
-
-    fun sendMessage(
-        chatRoomId: Long,
-        message: Message,
-    ) {
-        val sessions = chatRooms[chatRoomId]
-        sessions?.forEach { session ->
-            CompletableFuture // 비동기 처리
-                .supplyAsync(
-                    {
-                        if (session.isOpen) {
-                            try {
-                                session.sendMessage(TextMessage(JsonUtil.toJson(ChatSendMessageDto(message.sender.id, message.content, message.createdAt, message.type))))
-                            } catch (e: Exception) {
-                                e.printStackTrace()
-                            }
-                        }
-                    },
-                    executor,
-                )
-        }
     }
 
     override fun afterConnectionClosed(
         session: WebSocketSession,
         status: CloseStatus,
     ) {
-        val chatRoomId = getChatRoomId(session)
+        /**
+         * 웹소켓 연결이 종료되면 온라인 유저 목록에서 제거됩니다.
+         */
         val memberId = getMemberId(session)
-        chatRooms[chatRoomId]?.remove(session) // 세션 제거
-        messageCommandService.disconnectChatRoom(chatRoomId, memberId, session)
+        messageCommandService.removeOnlineUser(memberId, session)
         // TODO : 채팅방 나가기 실패 시 에러 처리
-    }
-
-    // 채팅방 ID를 URI에서 추출하는 함수
-    private fun getChatRoomId(session: WebSocketSession): Long {
-        val uri = session.uri.toString().split("?")[0]
-        return uri.substringAfterLast("/").toLong()
-        // TODO : 채팅방 아이디 얻기 실패 시 에러 처리
     }
 
     private fun getMemberId(session: WebSocketSession): Long = session.attributes["MEMBER_ID"] as Long

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -26,8 +26,10 @@ class ChatWebSocketHandler(
         chatRoomId: Long,
         memberId: Long,
     ) {
-        connectedParticipants.putIfAbsent(chatRoomId, mutableSetOf())
-        connectedParticipants[chatRoomId]?.add(memberId)
+        connectedParticipants
+            .computeIfAbsent(chatRoomId) {
+                ConcurrentHashMap.newKeySet()
+            }.add(memberId)
     }
 
     private fun removeParticipant(

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -1,6 +1,7 @@
 package com.friends.chat.websocket
 
 import com.friends.chat.dto.ChatReceiveMessageDto
+import com.friends.chat.repository.ChatRoomMemberRepository
 import com.friends.common.util.JsonUtil
 import com.friends.message.entity.MessageType
 import com.friends.message.service.MessageCommandService
@@ -14,30 +15,42 @@ import java.util.concurrent.ConcurrentHashMap
 @Component
 class ChatWebSocketHandler(
     private val messageCommandService: MessageCommandService,
+    private val chatRoomMemberRepository: ChatRoomMemberRepository,
 ) : TextWebSocketHandler() {
     // 채팅방 ID를 키로 하고, 참여하고 있는 member의 id를 value로 하는 Map
-    private val participants = ConcurrentHashMap<Long, MutableSet<Long>>()
+    private val connectedParticipants = ConcurrentHashMap<Long, MutableSet<Long>>()
     // memberId 를 키로 하고, WebSocketSession을 value로 하는 Map
     private val sessions = ConcurrentHashMap<Long, WebSocketSession>()
 
-    fun addParticipant(
+    private fun addParticipant(
         chatRoomId: Long,
         memberId: Long,
     ) {
-        participants.putIfAbsent(chatRoomId, mutableSetOf())
-        participants[chatRoomId]?.add(memberId)
+        connectedParticipants.putIfAbsent(chatRoomId, mutableSetOf())
+        connectedParticipants[chatRoomId]?.add(memberId)
     }
 
-    fun removeParticipant(
+    private fun removeParticipant(
         chatRoomId: Long,
         memberId: Long,
     ) {
-        participants[chatRoomId]?.remove(memberId)
+        connectedParticipants[chatRoomId]?.remove(memberId)
     }
 
     override fun afterConnectionEstablished(session: WebSocketSession) {
+        /**
+         * 웹소켓 연결 후 메세지를 수신받기 위해 sessions Map 에 저장합니다.
+         */
         val memberId = getMemberId(session)
         sessions.putIfAbsent(memberId, session)
+
+        /**
+         * 메세지를 수신할 채팅방(참여중인 모든 채팅방)을 추가합니다.
+         */
+        val chatRoomMemberList = chatRoomMemberRepository.findAllByMemberId(memberId)
+        chatRoomMemberList.forEach { chatRoomMember ->
+            addParticipant(chatRoomMember.chatRoom.id, memberId)
+        }
     }
 
     override fun handleTextMessage(
@@ -55,7 +68,7 @@ class ChatWebSocketHandler(
         /**
          * 채팅방에 참여하고 있는 모든 유저에게 메세지를 전송합니다.
          */
-        participants[chatRoomId]?.forEach { participantId ->
+        connectedParticipants[chatRoomId]?.forEach { participantId ->
             sessions[participantId]?.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
         }
         // TODO : 메세지 전송 실패 시 에러 처리
@@ -65,9 +78,18 @@ class ChatWebSocketHandler(
         session: WebSocketSession,
         status: CloseStatus,
     ) {
+        /**
+         * 웹소켓 연결 종료 후 sessions Map 에서 제거합니다.
+         */
         val memberId = getMemberId(session)
         sessions.remove(memberId)
-        // TODO : 채팅방 나가기 실패 시 에러 처리
+        /**
+         * 메세지를 수신하지 않도록 연결된 채팅방을 제거합니다.
+         */
+        val chatRoomMemberList = chatRoomMemberRepository.findAllByMemberId(memberId)
+        chatRoomMemberList.forEach { chatRoomMember ->
+            removeParticipant(chatRoomMember.chatRoom.id, memberId)
+        }
     }
 
     private fun getMemberId(session: WebSocketSession): Long = session.attributes["MEMBER_ID"] as Long

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -10,7 +10,6 @@ import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.TextWebSocketHandler
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArraySet
 
 @Component
 class ChatWebSocketHandler(
@@ -21,11 +20,24 @@ class ChatWebSocketHandler(
     // memberId 를 키로 하고, WebSocketSession을 value로 하는 Map
     private val sessions = ConcurrentHashMap<Long, WebSocketSession>()
 
+    fun addParticipant(
+        chatRoomId: Long,
+        memberId: Long,
+    ) {
+        participants.putIfAbsent(chatRoomId, mutableSetOf())
+        participants[chatRoomId]?.add(memberId)
+    }
+
+    fun removeParticipant(
+        chatRoomId: Long,
+        memberId: Long,
+    ) {
+        participants[chatRoomId]?.remove(memberId)
+    }
+
     override fun afterConnectionEstablished(session: WebSocketSession) {
-        val chatRoomId = getChatRoomId(session)
-        chatRooms.computeIfAbsent(chatRoomId) { CopyOnWriteArraySet() }
-        chatRooms[chatRoomId]?.add(session)
-        // TODO : 채팅방 입장 실패 시 에러 처리
+        val memberId = getMemberId(session)
+        sessions.putIfAbsent(memberId, session)
     }
 
     override fun handleTextMessage(
@@ -33,18 +45,18 @@ class ChatWebSocketHandler(
         message: TextMessage,
     ) {
         val chatMessage = JsonUtil.fromJson<ChatReceiveMessageDto>(message.payload)
-        val chatRoomId = getChatRoomId(session)
+        val chatRoomId = chatMessage.chatRoomId
         val memberId = getMemberId(session)
         /**
          * 채팅 웹소켓을 통해 보내는 메세지는 TEXT 타입만 있다고 가정합니다.
          * 이미지의 경우 웹소켓이 아닌 REST API 를 톹ㅇ해 이미지를 업로드하고 이미지 URL 을 채팅방에 보내는 방식으로 구현합니다. // TODO : 채팅방 내에서 이미지 전송하는 API 구현
          */
         val sendMessageDto = messageCommandService.saveMessage(chatRoomId, memberId, chatMessage.message, MessageType.TEXT)
-        val sessions = chatRooms[chatRoomId]
-        sessions?.forEach { session ->
-            if (session.isOpen) {
-                session.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
-            }
+        /**
+         * 채팅방에 참여하고 있는 모든 유저에게 메세지를 전송합니다.
+         */
+        participants[chatRoomId]?.forEach { participantId ->
+            sessions[participantId]?.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
         }
         // TODO : 메세지 전송 실패 시 에러 처리
     }
@@ -53,18 +65,9 @@ class ChatWebSocketHandler(
         session: WebSocketSession,
         status: CloseStatus,
     ) {
-        val chatRoomId = getChatRoomId(session)
         val memberId = getMemberId(session)
-        chatRooms[chatRoomId]?.remove(session) // 세션 제거
-        messageCommandService.disconnectChatRoom(chatRoomId, memberId, session)
+        sessions.remove(memberId)
         // TODO : 채팅방 나가기 실패 시 에러 처리
-    }
-
-    // 채팅방 ID를 URI에서 추출하는 함수
-    private fun getChatRoomId(session: WebSocketSession): Long {
-        val uri = session.uri.toString().split("?")[0]
-        return uri.substringAfterLast("/").toLong()
-        // TODO : 채팅방 아이디 얻기 실패 시 에러 처리
     }
 
     private fun getMemberId(session: WebSocketSession): Long = session.attributes["MEMBER_ID"] as Long

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebsocketInterceptor.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebsocketInterceptor.kt
@@ -20,9 +20,8 @@ class ChatWebsocketInterceptor(
         attributes: MutableMap<String, Any>,
     ): Boolean {
         /**
-         * WebSocket 연결 요청 시 http 방식으로 handshake 하는 스레드와
-         * WebSocket 연결 이후 메세지를 주고 받는 스레드가 다르기 때문에 SecurityContextHolder에 인증 정보가 없습니다.
-         * 인증 정보를 연결 이후에 사용자 인증 정보를 사용할 수 있도록 WebSocketHandler에서 attributes에 저장합니다.
+         * WebSocket 연결 요청 시 http 방식으로 handshake 하는 스레드에서 실행됩니다.
+         * 연결 이후에 사용자 인증 정보를 사용할 수 있도록 WebSocketHandler에서 attributes에 저장합니다.
          */
         val queryParams = (request as ServletServerHttpRequest).servletRequest.parameterMap
         val token = queryParams["token"]?.firstOrNull() ?: throw IllegalArgumentException("Token is required")

--- a/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
@@ -48,7 +48,7 @@ class SpringSecurityConfig(
                     "/api/global/**",
                     "/swagger-ui/**",
                     "/v3/api-docs/**",
-                    "ws/chatRoom/**",
+                    "ws/chat/**",
                 ).permitAll()
                 .requestMatchers("/api/user/**")
                 .hasAuthority(Role.ROLE_USER.name)

--- a/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/WebSocketConfig.kt
@@ -15,7 +15,7 @@ class WebSocketConfig(
 ) : WebSocketConfigurer {
     override fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
         registry
-            .addHandler(chatWebSocketHandler, "/ws/chatRoom/{chatRoomId}")
+            .addHandler(chatWebSocketHandler, "/ws/chat")
             .addInterceptors(chatWebsocketInterceptor)
             .setAllowedOrigins("*") // CORS 허용
     }

--- a/friends_server/src/main/kotlin/com/friends/message/entity/Message.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/entity/Message.kt
@@ -41,6 +41,10 @@ class Message(
             sender: Member,
             chatRoom: ChatRoom,
         ): Message = of(chatRoom, sender, "${sender.nickname} 님이 입장하셨습니다.", MessageType.SYSTEM)
+
+        fun enterMessage(
+            nickname: String,
+        ): String = "$nickname 님이 입장하셨습니다."
     }
 }
 

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
@@ -4,6 +4,7 @@ import com.friends.chat.ChatRoomNotFoundException
 import com.friends.chat.dto.ChatSendMessageDto
 import com.friends.chat.repository.ChatRoomMemberRepository
 import com.friends.chat.repository.ChatRoomRepository
+import com.friends.common.util.JsonUtil
 import com.friends.member.MemberNotFoundException
 import com.friends.member.repository.MemberRepository
 import com.friends.message.entity.Message
@@ -11,6 +12,11 @@ import com.friends.message.entity.MessageType
 import com.friends.message.repository.MessageRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutorService
 
 @Service
 class MessageCommandService(
@@ -18,7 +24,46 @@ class MessageCommandService(
     private val memberRepository: MemberRepository,
     private val chatRoomRepository: ChatRoomRepository,
     private val chatRoomMemberRepository: ChatRoomMemberRepository,
+    private val executor: ExecutorService,
 ) {
+    /**
+     * 채팅방 ID를 키로 하고, 참여하고 있는 온라인 유저의 WebSocketSession을 값으로 하는 Map입니다.
+     * ConcurrentHashMap을 사용하여 thread-safe하게 구현합니다.
+     * value 의 MutableSet은 thread-safe 하지 않아서 ConcurrentHashMap.newKeySet()을 사용하여 thread-safe하게 구현합니다.
+     */
+    private val onlineUsers = ConcurrentHashMap<Long, MutableSet<WebSocketSession>>()
+
+    /**
+     * 참여하고 있는 모든 채팅방에 온라인 유저로 등록됩니다.
+     */
+    fun addOnlineUser(
+        memberId: Long,
+        session: WebSocketSession,
+    ) {
+        chatRoomMemberRepository
+            .findAllByMemberId(memberId)
+            .forEach { chatRoomMember ->
+                onlineUsers
+                    .computeIfAbsent(chatRoomMember.chatRoom.id) {
+                        ConcurrentHashMap.newKeySet()
+                    }.add(session)
+            }
+    }
+
+    /**
+     * 참여하고 있는 모든 채팅방에서 온라인 유저를 제거합니다.
+     */
+    fun removeOnlineUser(
+        memberId: Long,
+        session: WebSocketSession,
+    ) {
+        chatRoomMemberRepository
+            .findAllByMemberId(memberId)
+            .forEach { chatRoomMember ->
+                onlineUsers[chatRoomMember.chatRoom.id]?.remove(session)
+            }
+    }
+
     /**
      * 채팅방을 나갈 때마다 마지막으로 읽은 메세지 ID를 업데이트합니다.
      * 채팅방이 없거나 멤버가 없거나 채팅방 멤버가 아닐 경우 무시합니다.
@@ -43,12 +88,12 @@ class MessageCommandService(
      * 채팅방이 없거나 멤버가 없을 경우 예외를 발생시킵니다.
      */
     @Transactional
-    fun saveMessage(
+    fun sendMessage(
         chatRoomId: Long,
         memberId: Long,
-        message: String,
+        content: String,
         type: MessageType,
-    ): ChatSendMessageDto {
+    ): Message {
         /**
          * 메세지를 보낼 때마다 보낸 유저와 채팅방이 있는지 DB 에 확인합니다.
          * 이 과정이 비효율적일 경우 아래 프록시 객체를 생성하여 메세지를 보내는 로직을 고려합니다.
@@ -59,14 +104,37 @@ class MessageCommandService(
          */
         val chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow { ChatRoomNotFoundException() }
         val sender = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
+        val message = messageRepository.save(Message.of(chatRoom, sender, content, type))
 
-        val savedMessage = messageRepository.save(Message.of(chatRoom, sender, message, type))
-        return ChatSendMessageDto(
-            chatRoomId = chatRoomId,
-            senderId = sender.id,
-            message = savedMessage.content,
-            sendTime = savedMessage.createdAt,
-            type = savedMessage.type,
-        )
+        // 온라인 유저에게 메세지 전송
+        val sessions = onlineUsers[chatRoomId] ?: return message// 온라인 유저가 없으면 메세지를 보낼 필요가 없습니다.
+        sessions.forEach { session ->
+            CompletableFuture // 비동기 처리
+                .supplyAsync(
+                    {
+                        if (session.isOpen) {
+                            try {
+                                session.sendMessage(
+                                    TextMessage(
+                                        JsonUtil.toJson(
+                                            ChatSendMessageDto(
+                                                message.chatRoom.id,
+                                                message.sender.id,
+                                                message.content,
+                                                message.createdAt,
+                                                message.type,
+                                            ),
+                                        ),
+                                    ),
+                                )
+                            } catch (e: Exception) {
+                                e.printStackTrace()
+                            }
+                        }
+                    },
+                    executor,
+                )
+        }
+        return message
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
@@ -11,7 +11,6 @@ import com.friends.message.entity.MessageType
 import com.friends.message.repository.MessageRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.socket.WebSocketSession
 
 @Service
 class MessageCommandService(
@@ -28,7 +27,6 @@ class MessageCommandService(
     fun disconnectChatRoom(
         chatRoomId: Long,
         memberId: Long,
-        session: WebSocketSession,
     ) {
         val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null) ?: return // 채팅방이 없을 경우 무시
         val member = memberRepository.findById(memberId).orElse(null) ?: return // 멤버가 없을 경우 무시
@@ -64,6 +62,7 @@ class MessageCommandService(
 
         val savedMessage = messageRepository.save(Message.of(chatRoom, sender, message, type))
         return ChatSendMessageDto(
+            chatRoomId = chatRoomId,
             senderId = sender.id,
             message = savedMessage.content,
             sendTime = savedMessage.createdAt,

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
@@ -64,6 +64,7 @@ class MessageCommandService(
 
         val savedMessage = messageRepository.save(Message.of(chatRoom, sender, message, type))
         return ChatSendMessageDto(
+            chatRoomId = chatRoom.id,
             senderId = sender.id,
             message = savedMessage.content,
             sendTime = savedMessage.createdAt,

--- a/friends_server/src/test/kotlin/com/friends/chat/service/ChatRoomCommandServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/chat/service/ChatRoomCommandServiceTest.kt
@@ -11,14 +11,13 @@ import com.friends.chat.entity.ChatRoomCategory
 import com.friends.chat.repository.ChatRoomCategoryRepository
 import com.friends.chat.repository.ChatRoomMemberRepository
 import com.friends.chat.repository.ChatRoomRepository
-import com.friends.chat.websocket.ChatWebSocketHandler
 import com.friends.createTestCategory
 import com.friends.image.S3ClientService
 import com.friends.member.MEMBER_ID
 import com.friends.member.createTestMember
 import com.friends.member.repository.MemberRepository
 import com.friends.message.entity.Message
-import com.friends.message.repository.MessageRepository
+import com.friends.message.service.MessageCommandService
 import com.friends.support.createTestImageFile
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -35,10 +34,9 @@ class ChatRoomCommandServiceTest :
             val memberRepository = mockk<MemberRepository>()
             val categoryRepository = mockk<CategoryRepository>()
             val chatRoomCategoryRepository = mockk<ChatRoomCategoryRepository>()
-            val messageRepository = mockk<MessageRepository>()
-            val chatWebSocketHandler = mockk<ChatWebSocketHandler>()
             val s3ClientService = mockk<S3ClientService>()
-            val chatRoomCommandService = ChatRoomCommandService(chatRoomRepository, chatRoomMemberRepository, memberRepository, categoryRepository, chatRoomCategoryRepository, messageRepository, s3ClientService, chatWebSocketHandler)
+            val messageCommandService = mockk<MessageCommandService>()
+            val chatRoomCommandService = ChatRoomCommandService(chatRoomRepository, chatRoomMemberRepository, memberRepository, categoryRepository, chatRoomCategoryRepository, s3ClientService, messageCommandService)
 
             given("createChatRoom 테스트") {
                 val request = createTestChatRoomCreateRequestDto()
@@ -47,7 +45,7 @@ class ChatRoomCommandServiceTest :
                 every { chatRoomMemberRepository.save(any()) } returns createTestChatRoomMember()
                 every { categoryRepository.findByIdIn(any()) } returns listOf(createTestCategory())
                 every { chatRoomCategoryRepository.saveAll(any<List<ChatRoomCategory>>()) } returns listOf(ChatRoomCategory.of(createTestChatRoom(), createTestCategory()))
-                every { messageRepository.save(any()) } returns Message.createEnterMessage(createTestMember(), createTestChatRoom())
+                every { messageCommandService.sendMessage(any(), any(), any(), any()) } returns Message.createEnterMessage(createTestMember(), createTestChatRoom())
                 every { s3ClientService.upload(any()) } returns "test"
                 `when`("정상적인 데이터가 들어올 경우") {
                     then("채팅방이 저장된다.") {
@@ -78,14 +76,13 @@ class ChatRoomCommandServiceTest :
                 every { memberRepository.findById(any()) } returns Optional.of(createTestMember())
                 every { chatRoomMemberRepository.existsChatRoomMemberByChatRoomAndMember(any(), any()) } returns false
                 every { chatRoomMemberRepository.save(any()) } returns createTestChatRoomMember()
-                every { messageRepository.save(any()) } returns Message.createEnterMessage(createTestMember(), createTestChatRoom())
-                every { chatWebSocketHandler.sendMessage(any(), any()) } returns Unit
+                every { messageCommandService.sendMessage(any(), any(), any(), any()) } returns Message.createEnterMessage(createTestMember(), createTestChatRoom())
                 `when`("정상적인 데이터가 들어올 경우") {
                     then("채팅방 멤버가 저장된다.") {
                         chatRoomCommandService.enterChatRoom(TEST_CHAT_ROOM_ID, MEMBER_ID)
                         verify(exactly = 1) {
                             chatRoomMemberRepository.save(any())
-                            messageRepository.save(any())
+                            messageCommandService.sendMessage(any(), any(), any(), any())
                         }
                     }
                 }
@@ -99,7 +96,7 @@ class ChatRoomCommandServiceTest :
                         }
                         verify(exactly = 0) {
                             chatRoomMemberRepository.save(any())
-                            messageRepository.save(any())
+                            messageCommandService.sendMessage(any(), any(), any(), any())
                         }
                     }
                 }
@@ -109,7 +106,7 @@ class ChatRoomCommandServiceTest :
                         every { chatRoomRepository.findById(any()) } returns Optional.empty()
                         shouldThrow<ChatRoomNotFoundException> {
                             chatRoomCommandService.enterChatRoom(TEST_CHAT_ROOM_ID, MEMBER_ID)
-                            verify(exactly = 0) { messageRepository.findById(any()) }
+                            verify(exactly = 0) { messageCommandService.sendMessage(any(), any(), any(), any()) }
                         }
                     }
                 }


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] 웹소켓 연결이 유저마다 1개씩 이루어질 수 있도록 변경하였습니다.
- [ ] 메세지 관련 서비스를 웹소켓 핸들러에서 분리하고 메세지 저장 및 발송을 묶어서 하나의 메소드로 만들었습니다.
- [ ] 메세지 발송 로직이 변경되어 영향을 받는 코드와 테스트를 수정하였습니다.

### 🔗 관련 이슈
- #127 와 #130 는 아직 해결하지 않았습니다.
예상되는 해결 방안은 이슈에 작성해두어서, 다음 PR 때 반영해보도록 하겠습니다

### 💬 기타 참고 사항
채팅방 생성, 입장 시에 입장 메세지를 전송하는 부분을 수정하였습니다. 
이에 따라 테스트도 약간 수정되었는데 문제되는 부분이 있는 확인해주세요 👍 

이제 동시성 이슈로 인해 messageRepository 를 통해 메세지를 다이렉트로 저장하는 것을 피해주시면 될 것 같습니다.
messageCommandService 에서 sendMessage 메소드를 사용하면 메세지를 저장하고 발송하며, 저장된 메시지를 반환받을 수 있습니다.
메세지를 저장해야하는 일이 있다면 이를 이용해주시면 감사하겠습니다 👍 