### PR TITLE
Fix/jwt filter

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/SpringSecurityConfig.kt
@@ -1,5 +1,6 @@
 package com.friends.config
 
+import com.friends.jwt.JwtService
 import com.friends.member.entity.Role
 import com.friends.security.authentication.AuthenticationCreator
 import com.friends.security.filter.JwtFilter
@@ -25,6 +26,7 @@ class SpringSecurityConfig(
     private val jwtFilterAccessDeniedHandler: JwtFilterAccessDeniedHandler,
     private val jwtFilterAuthenticationEntryPoint: JwtFilterAuthenticationEntryPoint,
     private val authenticationCreator: AuthenticationCreator,
+    private val jwtService: JwtService,
 ) {
     @Bean
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
@@ -34,7 +36,7 @@ class SpringSecurityConfig(
         http.csrf { it.disable() }
 
         http
-            .addFilterBefore(JwtFilter(authenticationCreator), UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(JwtFilter(authenticationCreator, jwtService), UsernamePasswordAuthenticationFilter::class.java)
             .exceptionHandling {
                 it
                     .accessDeniedHandler(jwtFilterAccessDeniedHandler)

--- a/friends_server/src/main/kotlin/com/friends/security/filter/JwtFilter.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/filter/JwtFilter.kt
@@ -1,5 +1,6 @@
 package com.friends.security.filter
 
+import com.friends.jwt.JwtService
 import com.friends.security.authentication.AuthenticationCreator
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
@@ -10,14 +11,16 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 class JwtFilter(
     private val authenticationCreator: AuthenticationCreator,
+    private val jwtService: JwtService,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain,
     ) {
-        resolveToken(request)?.let {
-            val authentication: Authentication = authenticationCreator.createByAccessToken(it)
+        val token = resolveToken(request)
+        if (token != null && jwtService.validate(token)) {
+            val authentication: Authentication = authenticationCreator.createByAccessToken(token)
             SecurityContextHolder.getContext().authentication = authentication
         }
         filterChain.doFilter(request, response)

--- a/friends_server/src/test/kotlin/com/friends/security/filter/JwtFilterTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/security/filter/JwtFilterTest.kt
@@ -2,6 +2,7 @@ package com.friends.security.filter
 
 import com.friends.jwt.AUTHORIZATION_HEADER
 import com.friends.jwt.INVALID_TOKEN
+import com.friends.jwt.JwtService
 import com.friends.jwt.VALID_TOKEN
 import com.friends.security.authentication.AuthenticationCreator
 import io.kotest.core.spec.style.BehaviorSpec
@@ -18,7 +19,8 @@ import org.springframework.security.core.context.SecurityContextHolder
 class JwtFilterTest :
     BehaviorSpec({
         val authenticationCreator = mockk<AuthenticationCreator>()
-        val jwtFilter = JwtFilter(authenticationCreator)
+        val jwtService = mockk<JwtService>()
+        val jwtFilter = JwtFilter(authenticationCreator, jwtService)
 
         /**
          * Type이 Test인 테스트(여기서는 then) 이 끝난 뒤 실행됩니다.
@@ -39,6 +41,7 @@ class JwtFilterTest :
             val filterChain = mockk<FilterChain>(relaxed = true)
 
             every { authenticationCreator.createByAccessToken(token) } returns authentication
+            every { jwtService.validate(token) } returns true
 
             `when`("JwtFilter가 실행될 때") {
                 jwtFilter.doFilter(request, response, filterChain)
@@ -82,10 +85,14 @@ class JwtFilterTest :
         given("HTTP 요청에 잘못된 Authorization 헤더가 있는 경우") {
             val request =
                 MockHttpServletRequest().apply {
-                    addHeader(AUTHORIZATION_HEADER, INVALID_TOKEN)
+                    addHeader(AUTHORIZATION_HEADER, "Bearer $INVALID_TOKEN")
                 }
             val response = MockHttpServletResponse()
             val filterChain = mockk<FilterChain>(relaxed = true)
+
+            every {
+                jwtService.validate(INVALID_TOKEN)
+            } returns false
 
             `when`("JwtFilter가 실행될 때") {
                 jwtFilter.doFilter(request, response, filterChain)


### PR DESCRIPTION
## 📝 Pull Request 내용
 global api 에서 잘못된 jwt 를 넣어도 인증 절차가 진행되는 이슈를 해결하였습니다.

**에러 발생 이유**
jwtFilter 는 모든 api (global, user, admin ...) 에서 동작합니다.
인가 검사 필터가 jwtFilter 뒤에 있기 때문입니다.
따라서 global 한 api 에서도 jwt 가 주어지기만 하면 jwtFilter 가 동작했습니다.

### 📑 변경 사항
Authorization 헤더로 받은 jwt 값이 유효할 때만 jwtFilter 가 동작하도록 변경하였습니다.

### 🔗 관련 이슈
- close #117 

### 💬 기타 참고 사항
jwt 가 유효하지 않을 때는 jwtFilter 를 그냥 통과해버리는게 인증/인가 가 의도한 대로 작동하는 것이었습니다.
global api 에서는 jwt 가 유효하든 유효하지 않든 모두 통과해야하는 것이 맞고 (이후에도 걸러지는 필터가 없습니다.),
user api 와 같은 인가 api 에서는 유효하지 않은 jwt 가 넘어가도 이후에 인가 필터에서 걸러지기 때문입니다.
