### PR TITLE
fix : 웹소켓 세션으로 ConcurrentWebSocketSessionDecorator 사용

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -9,16 +9,22 @@ import org.springframework.stereotype.Component
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
+import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator
 import org.springframework.web.socket.handler.TextWebSocketHandler
 
 @Component
 class ChatWebSocketHandler(
     private val messageCommandService: MessageCommandService,
 ) : TextWebSocketHandler() {
+    companion object {
+        private const val SEND_TIME_LIMIT = 2000 // 2초
+        private const val BUFFER_SIZE_LIMIT = 1024 * 1024 // 1MB
+    }
+
     override fun afterConnectionEstablished(session: WebSocketSession) {
         try {
             val memberId = getMemberId(session)
-            messageCommandService.setAllChatRoomsOnline(memberId, session)
+            messageCommandService.setAllChatRoomsOnline(memberId, ConcurrentWebSocketSessionDecorator(session, SEND_TIME_LIMIT, BUFFER_SIZE_LIMIT))
         } catch (e: Exception) {
             session.close(CloseStatus.SERVER_ERROR)// 채팅방 연결 종료 후 에러 처리
             throw UnexpectedChatRoomException(e)

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
@@ -137,6 +137,7 @@ class MessageCommandService(
     ): Message {
         val chatRoomLock = chatRoomLocks.computeIfAbsent(chatRoomId) { Any() }
 
+        // 채팅방 단위로 동기화 (synchronized block)
         synchronized(chatRoomLock) {
             /**
              * 메세지를 보낼 때마다 보낸 유저와 채팅방이 있는지 DB 에 확인합니다.

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
@@ -24,7 +24,7 @@ class MessageCommandService(
     private val memberRepository: MemberRepository,
     private val chatRoomRepository: ChatRoomRepository,
     private val chatRoomMemberRepository: ChatRoomMemberRepository,
-    private val executor: ExecutorService,
+    private val virtualThreadExecutor: ExecutorService,
 ) {
     /**
      * 채팅방 ID를 키로 하고, 참여하고 있는 온라인 유저의 아이디를 값으로 하는 Map입니다.
@@ -38,6 +38,11 @@ class MessageCommandService(
      * 하나의 유저가 여러개의 세션을 가질 수 있기 때문에 MutableSet을 사용합니다. (ex. 웹, 모바일 에서 동시 접속)
      */
     private val sessions = ConcurrentHashMap<Long, MutableSet<WebSocketSession>>()
+
+    /**
+     * 채팅방 ID를 키로 하여, 해당 채팅방에서 메시지를 보낼 때 동기화에 사용할 Lock 객체를 관리합니다.
+     */
+    private val chatRoomLocks = ConcurrentHashMap<Long, Any>()
 
     /**
      * 참여하고 있는 모든 채팅방에 온라인 유저로 등록됩니다.
@@ -130,51 +135,53 @@ class MessageCommandService(
         content: String,
         type: MessageType,
     ): Message {
-        /**
-         * 메세지를 보낼 때마다 보낸 유저와 채팅방이 있는지 DB 에 확인합니다.
-         * 이 과정이 비효율적일 경우 아래 프록시 객체를 생성하여 메세지를 보내는 로직을 고려합니다.
-         * 프록시 객체는 DB 에서 채팅방과 유저 정보를 요청하지 않지만, DB 에 데이터가 있는지 없는지 확인할 수 없습니다.
-         *
-         * val chatRoom = entityManager.getReference(ChatRoom::class.java, chatRoomId)
-         * val sender = entityManager.getReference(Member::class.java, message.senderId)
-         */
-        val chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow { ChatRoomNotFoundException() }
-        val sender = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
-        val message = messageRepository.save(Message.of(chatRoom, sender, content, type))
+        val chatRoomLock = chatRoomLocks.computeIfAbsent(chatRoomId) { Any() }
 
-        // 채팅방의 모든 온라인 유저에게 메세지 전송
-        val onlineUserIdSet = onlineUsers[chatRoomId] ?: return message// 온라인 유저가 없으면 메세지를 보낼 필요가 없습니다.
-        onlineUserIdSet.forEach {
-            val sessions = sessions[it] ?: return@forEach // 온라인 유저의 세션이 없으면 메세지를 보낼 필요가 없습니다.
-            // 온라인 유저와 연결된 모든 웹소켓에 메세지 전송
-            sessions.forEach { session ->
-                CompletableFuture // 비동기 처리
-                    .supplyAsync(
-                        {
+        synchronized(chatRoomLock) {
+            /**
+             * 메세지를 보낼 때마다 보낸 유저와 채팅방이 있는지 DB 에 확인합니다.
+             * 이 과정이 비효율적일 경우 아래 프록시 객체를 생성하여 메세지를 보내는 로직을 고려합니다.
+             * 프록시 객체는 DB 에서 채팅방과 유저 정보를 요청하지 않지만, DB 에 데이터가 있는지 없는지 확인할 수 없습니다.
+             *
+             * val chatRoom = entityManager.getReference(ChatRoom::class.java, chatRoomId)
+             * val sender = entityManager.getReference(Member::class.java, message.senderId)
+             */
+            val chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow { ChatRoomNotFoundException() }
+            val sender = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
+            val message = messageRepository.save(Message.of(chatRoom, sender, content, type))
+
+            // 채팅방의 모든 온라인 유저에게 메세지 전송
+            val onlineUserIdSet = onlineUsers[chatRoomId] ?: return message// 온라인 유저가 없으면 메세지를 보낼 필요가 없습니다.
+            val futures = mutableListOf<CompletableFuture<*>>()
+            onlineUserIdSet.forEach { userId ->
+                val userSessions = sessions[userId] ?: return@forEach
+                userSessions.forEach { session ->
+                    // 비동기 전송
+                    val future =
+                        CompletableFuture.supplyAsync({
                             if (session.isOpen) {
                                 try {
-                                    session.sendMessage(
-                                        TextMessage(
-                                            JsonUtil.toJson(
-                                                ChatSendMessageDto(
-                                                    chatRoom.id,
-                                                    sender.id,
-                                                    message.content,
-                                                    message.createdAt,
-                                                    message.type,
-                                                ),
-                                            ),
-                                        ),
-                                    )
+                                    val sendMessageDto =
+                                        ChatSendMessageDto(
+                                            chatRoom.id,
+                                            sender.id,
+                                            message.content,
+                                            message.createdAt,
+                                            message.type,
+                                        )
+                                    session.sendMessage(TextMessage(JsonUtil.toJson(sendMessageDto)))
                                 } catch (e: Exception) {
                                     e.printStackTrace()
                                 }
                             }
-                        },
-                        executor,
-                    )
+                        }, virtualThreadExecutor)
+                    futures.add(future)
+                }
             }
+            // 모든 메세지 전송이 완료될 때까지 대기
+            CompletableFuture.allOf(*futures.toTypedArray()).join()
+
+            return message
         }
-        return message
     }
 }


### PR DESCRIPTION
## 📝 Pull Request 내용
하나의 웹소켓에 여러 스레드에서 동시에 메세지를 전송할 경우 에러가 날 수도 있다고 하더군요
웹소켓 세션을 ConcurrentWebSocketSessionDecorator 으로 생성하여 세션의 메시지 전송은 하나의 스레드에서 이뤄지도록 하였습니다!
[참고자료 - 웹소켓 동시성 세션 참고 ](https://velog.io/@koseungbin/WebSocket#websocket-session-%EB%8F%99%EC%8B%9C%EC%84%B1)
[참고 자료 - ConcurrentWebSocketSessionDecorator](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/socket/handler/ConcurrentWebSocketSessionDecorator.html)
### 📑 변경 사항
- [ ] 저장하는 세션 객체를 WebSocketSession 에서 ConcurrentWebSocketSessionDecorator 으로 변경하였습니다.
- [ ] SEND_TIME_LIMIT 은 메세지 전송이 몇 초 이상 지연될 경우 세션을 종료할 것인지 발생하게 할 것인지를 나타냅니다.
- [ ] BUFFER_SIZE_LIMIT 은 동기화 전략 때문에 메시지 전송을 기다리는 메시지의 데이터 크기가 몇 이상일 때 세션을 종료할 것인지를 나타냅니다.
- [ ] 위의 값들을 통한 에러 처리 전략으로 세션 종료가 아닌 다른 처리를 할 수도 있던데, 디폴트 값인 세션 종료를 택했습니다.

### 🔗 관련 이슈
- #127 

### 💬 기타 참고 사항
Virtual Thread 안에서 synchronized 사용하는 지양하는 것이 좋다고 합니다. [참고 자료 - 우아한 형제들 Virutal Thread](https://techblog.woowahan.com/15398/)
synchronized 에서 Block 을 사용해버리면 Virutal Thread 가 아닌 OS Thread 가 잠겨버려 Virtual Thread 의 사용 철학을 벗어나기 때문이라고 이해했습니다.

ConcurrentWebSocketSessionDecorator 은 데코레이터 패턴을 사용한 객체로 WebSocketSession 을 받아서 생성됩니다.
![image](https://github.com/user-attachments/assets/bbbdf1ec-a0be-48b7-ab78-16abd99a04d1)

WebSocketSession 의 sendMessage 위에 추가로 동기화 로직을 감싸서 메세지 전송이 동기적으로 이뤄지도록 해줍니다.
![image](https://github.com/user-attachments/assets/83be77e5-7dfb-46fa-92a3-7c3778d96164)

이때 락을 거는 방법으로 ReentrantLock 을 사용하는데, 이는 OS Thread 를 Block 을 하지 않아 Virtual Thread 안에서도 문제없이 사용가능하다고 합니다.
따라서 기존의 코드와도 문제 없이 결합될 것 같습니다.
