### PR TITLE
Feature/websocket ping pong

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/FriendsServerApplication.kt
+++ b/friends_server/src/main/kotlin/com/friends/FriendsServerApplication.kt
@@ -7,9 +7,11 @@ import com.friends.config.OAuth2Properties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableConfigurationProperties(JwtProperties::class, AuthProperties::class, EmailProperties::class, OAuth2Properties::class)
+@EnableScheduling
 class FriendsServerApplication
 
 fun main(args: Array<String>) {

--- a/friends_server/src/main/kotlin/com/friends/chat/repository/PingPongRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/repository/PingPongRepository.kt
@@ -1,0 +1,19 @@
+package com.friends.chat.repository
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class PingPongRepository(
+    private val redisTemplate: RedisTemplate<String, String>,
+) {
+    fun savePing(webSocketSessionId: String) {
+        redisTemplate.opsForValue().set(webSocketSessionId, "ping")
+    }
+
+    fun deletePing(webSocketSessionId: String) {
+        redisTemplate.delete(webSocketSessionId)
+    }
+
+    fun existPing(webSocketSessionId: String): Boolean = redisTemplate.hasKey(webSocketSessionId)
+}

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -2,6 +2,7 @@ package com.friends.chat.websocket
 
 import com.friends.chat.UnexpectedChatRoomException
 import com.friends.chat.dto.ChatReceiveMessageDto
+import com.friends.chat.repository.PingPongRepository
 import com.friends.common.util.JsonUtil
 import com.friends.message.entity.MessageType
 import com.friends.message.service.MessageCommandService
@@ -15,6 +16,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler
 @Component
 class ChatWebSocketHandler(
     private val messageCommandService: MessageCommandService,
+    private val pingPongRepository: PingPongRepository,
 ) : TextWebSocketHandler() {
     companion object {
         private const val SEND_TIME_LIMIT = 2000 // 2초
@@ -35,6 +37,12 @@ class ChatWebSocketHandler(
         session: WebSocketSession,
         message: TextMessage,
     ) {
+        // ping / pong
+        if (message.payload.equals("pong", ignoreCase = true)) {
+            pingPongRepository.deletePing(session.id)
+            return
+        }
+
         val chatMessage = JsonUtil.fromJson<ChatReceiveMessageDto>(message.payload)
         val memberId = getMemberId(session)
         /**

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
@@ -4,12 +4,14 @@ import com.friends.chat.ChatRoomNotFoundException
 import com.friends.chat.dto.ChatSendMessageDto
 import com.friends.chat.repository.ChatRoomMemberRepository
 import com.friends.chat.repository.ChatRoomRepository
+import com.friends.chat.repository.PingPongRepository
 import com.friends.common.util.JsonUtil
 import com.friends.member.MemberNotFoundException
 import com.friends.member.repository.MemberRepository
 import com.friends.message.entity.Message
 import com.friends.message.entity.MessageType
 import com.friends.message.repository.MessageRepository
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.socket.TextMessage
@@ -25,6 +27,7 @@ class MessageCommandService(
     private val chatRoomRepository: ChatRoomRepository,
     private val chatRoomMemberRepository: ChatRoomMemberRepository,
     private val virtualThreadExecutor: ExecutorService,
+    private val pingPongRepository: PingPongRepository,
 ) {
     /**
      * 채팅방 ID를 키로 하고, 참여하고 있는 온라인 유저의 아이디를 값으로 하는 Map입니다.
@@ -38,6 +41,31 @@ class MessageCommandService(
      * 하나의 유저가 여러개의 세션을 가질 수 있기 때문에 MutableSet을 사용합니다. (ex. 웹, 모바일 에서 동시 접속)
      */
     private val sessions = ConcurrentHashMap<Long, MutableSet<WebSocketSession>>()
+
+    /**
+     * ping message 를 보내어 pong message 를 받지 못할 경우 세션을 제거합니다.
+     */
+    @Scheduled(fixedRate = 30000) // 30초 마다 실행
+    fun ping() {
+        for (entry in sessions) {
+            val userSessions = entry.value
+            userSessions.forEach { session ->
+                try {
+                    if (pingPongRepository.existPing(session.id)) {
+                        // pong 메세지를 받지 못할 경우 세션을 제거합니다.
+                        session.close()
+                        userSessions.remove(session)
+                    }
+                    session.sendMessage(TextMessage("ping"))
+                    pingPongRepository.savePing(session.id)
+                } catch (e: Exception) {
+                    // 에러가 발생할 경우 세션을 제거합니다.
+                    session.close()
+                    userSessions.remove(session)
+                }
+            }
+        }
+    }
 
     /**
      * 채팅방 ID를 키로 하여, 해당 채팅방에서 메시지를 보낼 때 동기화에 사용할 Lock 객체를 관리합니다.


### PR DESCRIPTION
## 📝 Pull Request 내용

실제로 웹소켓을 연결한 다음 네트워크를 끊어봤습니다.
그러나 여전히 서버에서는 세션이 연결되어있다고 인식하고 메세지를 전송하는 것이 가능했습니다.
클라이언트에서도 네트워크를 다시 연결하면 네트워크가 끊어졌을 때 받은 메세지가 한꺼번에 오는 현상이 발생했습니다.

이를 방지하기 위해 ping/pong 프레임을 구축하였습니다.

### 📑 변경 사항
- [ ] 스케쥴 코드를 작성하여 30초마다 ping 메세지를 클라이언트에게 보냅니다.
- [ ] ping 을 발송한 후 30초 내로 pong 메세지가 전달되지 않으면 세션을 종료하고 삭제합니다.

### 🔗 관련 이슈

- close #142 

### 💬 기타 참고 사항
