### PR TITLE
Refactor/ping pong

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/ChatMessageDto.kt
@@ -1,5 +1,6 @@
 package com.friends.chat.dto
 
+import com.friends.common.util.LocalDateTimeUtil
 import com.friends.message.entity.MessageType
 import java.time.LocalDateTime
 
@@ -14,7 +15,24 @@ data class ChatReceiveMessageDto(
 data class ChatSendMessageDto(
     val chatRoomId: Long,
     val senderId: Long,
-    val message: String,
-    val sendTime: LocalDateTime,
+    val content: String,
+    val createdAt: Long,
     val type: MessageType,
+) {
+    constructor(
+        chatRoomId: Long,
+        senderId: Long,
+        content: String,
+        createdAt: LocalDateTime,
+        type: MessageType,
+    ) : this(chatRoomId, senderId, content, LocalDateTimeUtil.toTimeStamp(createdAt), type)
+}
+
+enum class PingPongType {
+    PING,
+    PONG,
+}
+
+data class PingPongDto(
+    val type: String,
 )

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -2,6 +2,8 @@ package com.friends.chat.websocket
 
 import com.friends.chat.UnexpectedChatRoomException
 import com.friends.chat.dto.ChatReceiveMessageDto
+import com.friends.chat.dto.PingPongDto
+import com.friends.chat.dto.PingPongType
 import com.friends.chat.repository.PingPongRepository
 import com.friends.common.util.JsonUtil
 import com.friends.message.entity.MessageType
@@ -38,6 +40,16 @@ class ChatWebSocketHandler(
         message: TextMessage,
     ) {
         // ping / pong
+        try {
+            val pingPongDto = JsonUtil.fromJson<PingPongDto>(message.payload)
+            if (pingPongDto.type.equals(PingPongType.PONG.name, ignoreCase = true)) {
+                pingPongRepository.deletePing(session.id)
+                return
+            }
+        } catch (e: Exception) {
+            // ignore
+        }
+
         if (message.payload.equals("pong", ignoreCase = true)) {
             pingPongRepository.deletePing(session.id)
             return

--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -50,11 +50,6 @@ class ChatWebSocketHandler(
             // ignore
         }
 
-        if (message.payload.equals("pong", ignoreCase = true)) {
-            pingPongRepository.deletePing(session.id)
-            return
-        }
-
         val chatMessage = JsonUtil.fromJson<ChatReceiveMessageDto>(message.payload)
         val memberId = getMemberId(session)
         /**

--- a/friends_server/src/main/kotlin/com/friends/common/util/LocalDateTimeUtil.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/util/LocalDateTimeUtil.kt
@@ -1,0 +1,13 @@
+package com.friends.common.util
+
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+object LocalDateTimeUtil {
+    fun toTimeStamp(localDateTime: LocalDateTime): Long {
+        return localDateTime
+            .atZone(ZoneId.systemDefault()) // 시스템 시간대 적용
+            .toInstant() // Instant로 변환
+            .toEpochMilli() // 밀리초 기준 타임스탬프로 변환
+    }
+}

--- a/friends_server/src/main/kotlin/com/friends/message/dto/MessageDtos.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/dto/MessageDtos.kt
@@ -1,5 +1,6 @@
 package com.friends.message.dto
 
+import com.friends.common.util.LocalDateTimeUtil
 import com.friends.message.entity.MessageType
 import java.time.LocalDateTime
 
@@ -8,5 +9,13 @@ data class MessageResponseDto(
     val senderId: Long,
     val content: String,
     val type: MessageType,
-    val createdAt: LocalDateTime,
-)
+    val createdAt: Long,
+) {
+    constructor(
+        messageId: Long,
+        senderId: Long,
+        content: String,
+        type: MessageType,
+        createdAt: LocalDateTime,
+    ) : this(messageId, senderId, content, type, LocalDateTimeUtil.toTimeStamp(createdAt))
+}

--- a/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/service/MessageCommandService.kt
@@ -2,6 +2,8 @@ package com.friends.message.service
 
 import com.friends.chat.ChatRoomNotFoundException
 import com.friends.chat.dto.ChatSendMessageDto
+import com.friends.chat.dto.PingPongDto
+import com.friends.chat.dto.PingPongType
 import com.friends.chat.repository.ChatRoomMemberRepository
 import com.friends.chat.repository.ChatRoomRepository
 import com.friends.chat.repository.PingPongRepository
@@ -56,7 +58,7 @@ class MessageCommandService(
                         session.close()
                         userSessions.remove(session)
                     }
-                    session.sendMessage(TextMessage("ping"))
+                    session.sendMessage(TextMessage(JsonUtil.toJson(PingPongDto(PingPongType.PING.name.lowercase()))))
                     pingPongRepository.savePing(session.id)
                 } catch (e: Exception) {
                     // 에러가 발생할 경우 세션을 제거합니다.


### PR DESCRIPTION
## 📝 Pull Request 내용
프론트앤드 분들의 요청으로 메세지의 DTO 스펙을 수정하였습니다.

### 📑 변경 사항
- [ ] ping pong 프레임에서 메세지 송수신이 "{ "type" : "ping" } " 로 수정하였습니다.
- [ ] 웹소켓 메세지 DTO 의 변수명 과 메시지 조회 API 의 DTO 의 변수명을 통일하였습니다.
- [ ] 메세지의 생성 시간이 Long 으로 ms 인 TimeStamp 형식이 되도록 변경하였습니다

### 🔗 관련 이슈
- close #154 

### 💬 기타 참고 사항
- TimeStamp 방식은 이번주 회의에서 일부에만 적용할지 모든 API 에 통일할지 이야기해보면 좋을 것 같습니다~
