### PR TITLE
Feature/default imgae and last read message

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/controller/ChatRoomController.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/controller/ChatRoomController.kt
@@ -111,6 +111,7 @@ class ChatRoomController(
         chatRoomId: Long,
         @AuthenticationPrincipal
         memberId: Long,
+        @RequestParam
         forceLeaveMemberId: Long,
     ): ResponseEntity<Void> {
         chatRoomCommandService.forcedToLeave(chatRoomId, memberId, forceLeaveMemberId)

--- a/friends_server/src/main/kotlin/com/friends/chat/controller/ChatRoomController.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/controller/ChatRoomController.kt
@@ -107,7 +107,7 @@ class ChatRoomController(
     @DeleteMapping("/{id}/user")
     override fun forcedToLeave(
         @PathVariable("id")
-        @Positive(message = "채팅방 ID는 양수여야 합니다.")
+        @Positive(message = "chatRoomId는 0보다 커야 합니다.")
         chatRoomId: Long,
         @AuthenticationPrincipal
         memberId: Long,

--- a/friends_server/src/main/kotlin/com/friends/chat/dto/ChatRoomResponseDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/ChatRoomResponseDto.kt
@@ -20,7 +20,7 @@ data class ChatRoomInfoResponseDto(
     @Schema(description = "채팅방 참여자 프로필 리스트(최대 4명)")
     val participantProfileList: List<String>,
     @Schema(description = "채팅방 마지막 메세지 시간")
-    val lastMessageTime: LocalDateTime,
+    val lastMessageTime: LocalDateTime?,
     @Schema(description = "채팅방 마지막 메세지")
     val lastMessage: String?,
     @Schema(description = "안 읽은 메세지 수")

--- a/friends_server/src/main/kotlin/com/friends/chat/dto/mapper/ChatRoomResponseMapper.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/mapper/ChatRoomResponseMapper.kt
@@ -5,26 +5,17 @@ import com.friends.chat.dto.ChatRoomInfoResponseDto
 import com.friends.chat.entity.ChatRoom
 import com.friends.chat.entity.ChatRoomMember
 import com.friends.common.mapper.toCategoryInfoResponse
+import com.friends.message.entity.Message
 
 fun toChatRoomInfoResponse(
     chatRoomMember: ChatRoomMember,
     memberCount: Int,
     representativeProfile: List<String>,
     unreadMessageCount: Int,
+    lastMessage: Message?,
     imageUrl: String,
-): ChatRoomInfoResponseDto {
-    val lastChatRoomMessageTime =
-        // 마지막 읽은 메세지가 채팅방의 마지막 메세지보다 이전이면 채팅방의 마지막 메세지 시간을 가져옴 그렇지 않으면 자신의 입장 메세지가 보내진 시간을 갖고옴(마지막 읽은 메세지 자신의 입장 메세지로 초기화하기 때문)
-        if (chatRoomMember.chatRoom.lastMessage != null &&
-            chatRoomMember.chatRoom.lastMessage!!
-                .createdAt
-                .isAfter(chatRoomMember.lastReadMessage.createdAt)
-        ) {
-            chatRoomMember.chatRoom.lastMessage!!.createdAt
-        } else {
-            chatRoomMember.lastReadMessage.createdAt
-        }
-    return ChatRoomInfoResponseDto(
+): ChatRoomInfoResponseDto =
+    ChatRoomInfoResponseDto(
         chatRoomMemberId = chatRoomMember.id,
         id = chatRoomMember.chatRoom.id,
         title = chatRoomMember.chatRoom.title,
@@ -32,11 +23,10 @@ fun toChatRoomInfoResponse(
         categoryIdList = chatRoomMember.chatRoom.categories.map { toCategoryInfoResponse(it.category) },
         participantCount = memberCount,
         participantProfileList = representativeProfile,
-        lastMessageTime = lastChatRoomMessageTime,
+        lastMessageTime = lastMessage?.createdAt,
+        lastMessage = lastMessage?.content,
         unreadMessageCount = unreadMessageCount,
-        lastMessage = chatRoomMember.chatRoom.lastMessage?.content,
     )
-}
 
 fun toChatRoomDetailResponseDto(
     chatRoom: ChatRoom,

--- a/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomQueryService.kt
@@ -50,11 +50,13 @@ class ChatRoomQueryService(
             chatRoomMemberRepository
                 .sliceChatRoomIdByMember(memberId, friends, size, lastChatRoomMemberId)
                 .map {
+                    val lastMessage = messageRepository.findRecentMessageInChatRoom(it.chatRoom)
                     toChatRoomInfoResponse(
                         it,
                         chatRoomMemberRepository.countByChatRoom(it.chatRoom),
                         chatRoomMemberRepository.findRepresentativeProfileByChatRoomId(it.chatRoom.id).map { member -> member.profile?.imageUrl ?: profileBaseImageUrl },
                         messageRepository.countUnreadMessages(it).let { count -> if (count > 999) 999 else count },
+                        lastMessage,
                         it.chatRoom.imageUrl ?: chatRoomBaseImageUrl,
                     )
                 } //해당 채팅방 멤버 수와 읽지 않은 메세지 수를 가져옴

--- a/friends_server/src/main/kotlin/com/friends/common/util/JdslUtil.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/util/JdslUtil.kt
@@ -20,6 +20,10 @@ fun <T : Any> KotlinJdslJpqlExecutor.getSingle(
     init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
 ): T = this.findAll(init = init).first() as T
 
+fun <T : Any> KotlinJdslJpqlExecutor.find(
+    init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+): T? = this.findAll(init = init).firstOrNull()
+
 fun <T : Any> KotlinJdslJpqlExecutor.getLimitList(
     offset: Int,
     limit: Int,

--- a/friends_server/src/main/kotlin/com/friends/config/InitDB.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/InitDB.kt
@@ -3,18 +3,34 @@ package com.friends.config
 import com.friends.category.entity.Category
 import com.friends.category.entity.CategoryType
 import com.friends.category.repository.CategoryRepository
+import com.friends.chat.dto.ChatRoomCreateRequestDto
+import com.friends.chat.repository.ChatRoomRepository
+import com.friends.chat.service.ChatRoomCommandService
 import com.friends.member.entity.Member
 import com.friends.member.repository.MemberRepository
+import com.friends.profile.entity.GenderEnum
+import com.friends.profile.entity.Location
+import com.friends.profile.entity.MbtiEnum
+import com.friends.profile.entity.Profile
+import com.friends.profile.entity.ProfileInterestTag
+import com.friends.profile.repository.ProfileInterestTagRepository
+import com.friends.profile.repository.ProfileRepository
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
+import java.time.LocalDate
+import kotlin.random.Random
 
 @Component
 class InitDB(
     private val categoryRepository: CategoryRepository,
     private val memberRepository: MemberRepository,
     private val passwordEncoder: PasswordEncoder,
+    private val profileRepository: ProfileRepository,
+    private val profileInterestTagRepository: ProfileInterestTagRepository,
+    private val chatRoomCommandService: ChatRoomCommandService,
+    private val chatRoomRepository: ChatRoomRepository,
 ) {
     @Bean
     fun runInitializer(): ApplicationRunner =
@@ -77,5 +93,103 @@ class InitDB(
             categoryRepository.save(Category(name = "경상북도", type = CategoryType.REGION))
             categoryRepository.save(Category(name = "경상남도", type = CategoryType.REGION))
             categoryRepository.save(Category(name = "제주도", type = CategoryType.REGION))
+
+            // 100 명의 테스트 유저 생성
+            val categories = categoryRepository.findAll()
+            val members = mutableListOf<Member>()
+
+            for (i in 1..100) {
+                val member =
+                    memberRepository.save(
+                        Member.createUser(
+                            nickname = "test$i",
+                            email = "test$i@com",
+                            password = passwordEncoder.encode("password"),
+                        ),
+                    )
+                members.add(member)
+
+                val randomBirth =
+                    LocalDate.of(
+                        (1990..1999).random(),
+                        (1..12).random(),
+                        (1..28).random(),
+                    )
+                val randomGender = GenderEnum.entries.toTypedArray().random()
+                val randomLatitude = 38 + Random.nextDouble(0.0, 1.0)
+                val randomLongitude = 127 + Random.nextDouble(0.0, 1.0)
+                val randomLocation = Location(randomLatitude, randomLongitude)
+                val randomMbti = MbtiEnum.entries.toTypedArray().random()
+
+                val profile =
+                    profileRepository.save(
+                        Profile(
+                            member = member,
+                            // 생일은 1990년 1월 1일부터 1999년 12월 31일 사이의 랜덤한 날짜로 설정
+                            birth = randomBirth,
+                            gender = randomGender,
+                            imageUrl = "https://friends-bucket.s3.ap-northeast-2.amazonaws.com/2d397027-6448-414a-b155-17b5a41f6c34",
+                            location = randomLocation,
+                            mbti = randomMbti,
+                        ),
+                    )
+
+                // 1~10개의 랜덤한 카테고리를 저장
+                val randomCategoryCount = (1..10).random()
+                val randomCategories = categories.shuffled().take(randomCategoryCount)
+
+                randomCategories.map {
+                    profileInterestTagRepository.save(
+                        ProfileInterestTag(
+                            profile = profile,
+                            category = it,
+                        ),
+                    )
+                }
+            }
+
+            // 참여 중인 채팅방 10개 생성
+            for (i in 1..20) {
+                val randomInt = (3..7).random()
+                chatRoomCommandService.createChatRoom(
+                    ChatRoomCreateRequestDto(
+                        title = "채팅방 $i",
+                        categoryIdList =
+                            categories
+                                .shuffled()
+                                .take(randomInt)
+                                .map { it.id }
+                                .toSet(),
+                    ),
+                    members[0].id,
+                    null,
+                )
+            }
+            for (i in 20..30) {
+                val randomInt = (3..7).random()
+                chatRoomCommandService.createChatRoom(
+                    ChatRoomCreateRequestDto(
+                        title = "채팅방 $i",
+                        categoryIdList =
+                            categories
+                                .shuffled()
+                                .take(randomInt)
+                                .map { it.id }
+                                .toSet(),
+                    ),
+                    members[1].id,
+                    null,
+                )
+            }
+
+            // 채팅방에 10~20명의 유저를 랜덤하게 입장시킴
+            val chatRooms = chatRoomRepository.findAll()
+            for (chatRoom in chatRooms) {
+                val randomInt = (10..20).random()
+                val randomMembers = members.shuffled().take(randomInt)
+                for (member in randomMembers) {
+                    chatRoomCommandService.enterChatRoom(chatRoom.id, member.id)
+                }
+            }
         }
 }

--- a/friends_server/src/main/kotlin/com/friends/config/InitDB.kt
+++ b/friends_server/src/main/kotlin/com/friends/config/InitDB.kt
@@ -15,8 +15,8 @@ import com.friends.profile.entity.Profile
 import com.friends.profile.entity.ProfileInterestTag
 import com.friends.profile.repository.ProfileInterestTagRepository
 import com.friends.profile.repository.ProfileRepository
-import org.springframework.boot.ApplicationRunner
-import org.springframework.context.annotation.Bean
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -24,18 +24,30 @@ import kotlin.random.Random
 
 @Component
 class InitDB(
-    private val categoryRepository: CategoryRepository,
-    private val memberRepository: MemberRepository,
-    private val passwordEncoder: PasswordEncoder,
-    private val profileRepository: ProfileRepository,
-    private val profileInterestTagRepository: ProfileInterestTagRepository,
-    private val chatRoomCommandService: ChatRoomCommandService,
-    private val chatRoomRepository: ChatRoomRepository,
+    private val initTestMember: InitTestMember,
+    private val initCategory: InitCategory,
+    private val initTestUser: InitTestUser,
 ) {
-    @Bean
-    fun runInitializer(): ApplicationRunner =
+    @Value("\${spring.jpa.hibernate.ddl-auto}")
+    lateinit var ddlAuto: String
 
-        ApplicationRunner {
+    @PostConstruct
+    fun init() {
+        println(ddlAuto)
+        if (ddlAuto != "create") {
+            return
+        }
+        initTestMember.init()
+        initCategory.init()
+        initTestUser.init()
+    }
+
+    @Component
+    class InitTestMember(
+        private val memberRepository: MemberRepository,
+        private val passwordEncoder: PasswordEncoder,
+    ) {
+        fun init() {
             // 테스트 유저 생성
             memberRepository.saveAll(
                 listOf(
@@ -56,8 +68,14 @@ class InitDB(
                     ),
                 ),
             )
+        }
+    }
 
-            // 카테고리 생성
+    @Component
+    class InitCategory(
+        private val categoryRepository: CategoryRepository,
+    ) {
+        fun init() {
             categoryRepository.deleteAll()
             categoryRepository.save(Category(name = "자유수다", type = CategoryType.SUBJECT, image = "🧑‍🧑‍🧒"))
             categoryRepository.save(Category(name = "팬덤", type = CategoryType.SUBJECT, image = "🎈"))
@@ -93,7 +111,20 @@ class InitDB(
             categoryRepository.save(Category(name = "경상북도", type = CategoryType.REGION))
             categoryRepository.save(Category(name = "경상남도", type = CategoryType.REGION))
             categoryRepository.save(Category(name = "제주도", type = CategoryType.REGION))
+        }
+    }
 
+    @Component
+    class InitTestUser(
+        private val categoryRepository: CategoryRepository,
+        private val memberRepository: MemberRepository,
+        private val passwordEncoder: PasswordEncoder,
+        private val profileRepository: ProfileRepository,
+        private val profileInterestTagRepository: ProfileInterestTagRepository,
+        private val chatRoomCommandService: ChatRoomCommandService,
+        private val chatRoomRepository: ChatRoomRepository,
+    ) {
+        fun init() {
             // 100 명의 테스트 유저 생성
             val categories = categoryRepository.findAll()
             val members = mutableListOf<Member>()
@@ -192,4 +223,5 @@ class InitDB(
                 }
             }
         }
+    }
 }

--- a/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
@@ -2,6 +2,7 @@ package com.friends.message.repository
 
 import com.friends.chat.entity.ChatRoom
 import com.friends.chat.entity.ChatRoomMember
+import com.friends.common.util.find
 import com.friends.common.util.getList
 import com.friends.common.util.getSingle
 import com.friends.common.util.getSlice
@@ -37,6 +38,8 @@ interface MessageCustomRepository {
         messageId: Long? = null,
         size: Int,
     ): Slice<Message>
+
+    fun findRecentMessageInChatRoom(chatRoom: ChatRoom): Message?
 }
 
 class MessageCustomRepositoryImpl(
@@ -100,4 +103,16 @@ class MessageCustomRepositoryImpl(
         val sortedContent = slice.content.reversed()
         return SliceImpl(sortedContent, pageable, slice.hasNext())
     }
+
+    override fun findRecentMessageInChatRoom(chatRoom: ChatRoom): Message? =
+        kotlinJdslJpqlExecutor.find {
+            select(entity(Message::class))
+                .from(entity(Message::class))
+                .where(
+                    and(
+                        path(Message::chatRoom).equal(chatRoom),
+                        path(Message::type).notEqual(MessageType.SYSTEM),
+                    ),
+                ).orderBy(path(Message::id).desc())
+        }
 }

--- a/friends_server/src/main/kotlin/com/friends/recommendation/service/GlobalRecommendationService.kt
+++ b/friends_server/src/main/kotlin/com/friends/recommendation/service/GlobalRecommendationService.kt
@@ -3,6 +3,7 @@ package com.friends.recommendation.service
 import com.friends.common.dto.ListBaseResponse
 import com.friends.profile.dto.ProfileWithCategories
 import com.friends.profile.repository.ProfileRepository
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,6 +13,9 @@ import org.springframework.transaction.annotation.Transactional
 class GlobalRecommendationService(
     private val profileRepository: ProfileRepository,
 ) {
+    @Value("\${image.profile-base-url}")
+    lateinit var profileBaseImageUrl: String
+
     fun getCategoryRecommendation(
         categoryIds: List<Long>,
         size: Int,
@@ -24,7 +28,7 @@ class GlobalRecommendationService(
                 ProfileWithCategories(
                     it.id,
                     it.member.nickname,
-                    it.imageUrl,
+                    it.imageUrl ?: profileBaseImageUrl,
                     it.interestTag.map { tag -> tag.category.id },
                 )
             },

--- a/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
@@ -108,7 +108,7 @@ class AuthService(
         val profile =
             Profile(
                 member = user,
-                imageUrl = registerRequestDto.imageUrl ?: "default image url",
+                imageUrl = registerRequestDto.imageUrl,
                 gender = registerRequestDto.gender,
                 birth = LocalDate.of(registerRequestDto.birth, 1, 1),
                 location = registerRequestDto.location?.let { Location(it.latitude, it.longitude) },

--- a/friends_server/src/test/kotlin/com/friends/chat/ChatFixture.kt
+++ b/friends_server/src/test/kotlin/com/friends/chat/ChatFixture.kt
@@ -66,8 +66,9 @@ fun createTestChatRoomInfoResponseDto(
     memberCount: Int = TEST_SIZE,
     representativeProfile: List<String> = listOf(TEST_PROFILE_IMAGE_URL),
     unreadMessageCount: Int = 0,
+    lastReadMessage: Message = createTestMessage(),
     imageUrl: String = CHAT_ROOM_BASE_IMAGE_URL,
-) = toChatRoomInfoResponse(chatRoomMember, memberCount, representativeProfile, unreadMessageCount, imageUrl)
+) = toChatRoomInfoResponse(chatRoomMember, memberCount, representativeProfile, unreadMessageCount, lastReadMessage, imageUrl)
 
 fun createTestSliceResponseChatRoom(
     sliceChatRoom: Slice<ChatRoomMember> = createTestSliceChatRoom(),


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- 테스트 데이터 추가 
  - 100명의 유저, 30개의 채팅방을 만들고 각 채팅방에 유저를 참여시켰습니다.
  - 테스트 유저의 양식은 "test{i}@com" 을 이메일로 "password" 를 비밀번호로 가집니다.
  - 채팅방에 가입된 유저는 "test1@com" 과 "test2@com" 로 2명입니다.
- controller 의 spec 과 구현체에서 validation 애노테이션이 차이가 존재하는 경우 발생하는 에러를 수정하였습니다.
- 회원가입 시 프로필 이미지를 null 로 받을 경우 DB 에 null 로 저장하고 조회 API 에서 DB 에 저장된 값이 null 인 경우 default image url 을 반환할 수 있도록 변경하였습니다.
- 채팅방 리스트 조회 시 채팅방의 마지막 메세지를 조회하는 기능을 추가하였습니다.

### 🔗 관련 이슈

### 💬 기타 참고 사항
- 배포 전 PR 이라 여러 가지 기능이 잡다하게 들어가서 죄송합니다 ㅠ
- 변경 사항 중 2번째에서 발생한 에러는 API 를 직접 실행해봐야 알 수 있는 에러였습니다.
만들어주신 중에 API 를 실행했을 때 에러가 발생하지 않는 지 확인 부탁드립니다 👍 