### PR TITLE
fix: 내 프로필 조회값 수정

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/profile/dto/ProfileDtos.kt
+++ b/friends_server/src/main/kotlin/com/friends/profile/dto/ProfileDtos.kt
@@ -30,6 +30,7 @@ data class ProfileUpdateDto(
 
 //조회용 dto
 data class ProfileResponseDto(
+    val memberId: Long,
     val nickname: String,
     val email: String,
     var birth: LocalDate,

--- a/friends_server/src/main/kotlin/com/friends/profile/entity/ProfileEntity.kt
+++ b/friends_server/src/main/kotlin/com/friends/profile/entity/ProfileEntity.kt
@@ -58,6 +58,7 @@ class Profile(
 
     fun toResponseDto(): ProfileResponseDto =
         ProfileResponseDto(
+            memberId = this.member.id,
             nickname = this.member.nickname,
             email = this.member.email,
             birth = this.birth,

--- a/friends_server/src/test/kotlin/com/friends/profile/ProfileFixture.kt
+++ b/friends_server/src/test/kotlin/com/friends/profile/ProfileFixture.kt
@@ -36,7 +36,7 @@ fun createTestProfile(
     gender: GenderEnum = GenderEnum.MAN,
 ): Profile = Profile(member = member, birth = birth, gender = gender, mbti = MbtiEnum.ENFJ, location = Location(10.0, 10.0), selfDescription = "test self description", imageUrl = "test imageurl")
 
-fun createTestProfileResponseDto(): ProfileResponseDto = ProfileResponseDto(nickname = createTestMember().nickname, email = "test@test.com", birth = LocalDate.now(), gender = GenderEnum.MAN, location = Location(10.0, 10.0), selfDescription = "test self description", imageUrl = "test imageurl", mbti = MbtiEnum.ENFJ)
+fun createTestProfileResponseDto(): ProfileResponseDto = ProfileResponseDto(memberId = createTestMember().id,  nickname = createTestMember().nickname, email = "test@test.com", birth = LocalDate.now(), gender = GenderEnum.MAN, location = Location(10.0, 10.0), selfDescription = "test self description", imageUrl = "test imageurl", mbti = MbtiEnum.ENFJ)
 
 fun createTestProfileCreateDto(): ProfileCreateDto = ProfileCreateDto(birth = LocalDate.now(), gender = GenderEnum.MAN, location = Location(10.0, 10.0), selfDescription = "test self description", imageUrl = TEST_IMAGE_FILE_URL)
 


### PR DESCRIPTION
## 📝 Pull Request 내용
프로필 조회 응답값 수정

### 📑 변경 사항
- [ ] 내 프로필 조회 시 응답값에 memberId를 포함해달라는 요청이 있어서 profileResponseDto 수정했습니다.

### 🔗 관련 이슈
- #29 

### 💬 기타 참고 사항
-x
