### PR TITLE
Feature/alarm unread count

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/alarm/controller/AlarmController.kt
+++ b/friends_server/src/main/kotlin/com/friends/alarm/controller/AlarmController.kt
@@ -24,4 +24,12 @@ class AlarmController(
         val result = alarmQueryService.getAlarmList(memberId, size, lastAlarmId)
         return ResponseEntity.ok(result)
     }
+
+    @GetMapping("/unread-count")
+    override fun getUnreadAlarmCount(
+        @AuthenticationPrincipal memberId: Long,
+    ): ResponseEntity<Long> {
+        val result = alarmQueryService.getUnreadAlarmCount(memberId)
+        return ResponseEntity.ok(result)
+    }
 }

--- a/friends_server/src/main/kotlin/com/friends/alarm/controller/AlarmControllerSpec.kt
+++ b/friends_server/src/main/kotlin/com/friends/alarm/controller/AlarmControllerSpec.kt
@@ -10,7 +10,9 @@ import org.springframework.http.ResponseEntity
 @Tag(name = "Alarm", description = "알람 API")
 interface AlarmControllerSpec {
     @Operation(
-        description = "알람 조회 API",
+        description =
+            "알람 조회 API <br>" +
+                "API 호출 후 사용자의 모든 알림은 읽음 처리 됩니다.",
         responses = [
             ApiResponse(
                 responseCode = "200",
@@ -23,4 +25,15 @@ interface AlarmControllerSpec {
         size: Int,
         lastAlarmId: Long?,
     ): ResponseEntity<SliceBaseResponse<AlarmResponseDto>>
+
+    @Operation(
+        description = "알람 읽지 않은 개수 조회 API",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "알람 읽지 않은 개수 조회 성공",
+            ),
+        ],
+    )
+    fun getUnreadAlarmCount(memberId: Long): ResponseEntity<Long>
 }

--- a/friends_server/src/main/kotlin/com/friends/alarm/entity/MemberLastReadAlarm.kt
+++ b/friends_server/src/main/kotlin/com/friends/alarm/entity/MemberLastReadAlarm.kt
@@ -1,0 +1,22 @@
+package com.friends.alarm.entity
+
+import com.friends.member.entity.Member
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+
+@Entity
+class MemberLastReadAlarm(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    val member: Member,
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "alarm_id")
+    val alarm: Alarm,
+)

--- a/friends_server/src/main/kotlin/com/friends/alarm/repository/AlarmRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/alarm/repository/AlarmRepository.kt
@@ -1,6 +1,7 @@
 package com.friends.alarm.repository
 
 import com.friends.alarm.entity.Alarm
+import com.friends.common.util.getSingle
 import com.friends.common.util.getSlice
 import com.friends.member.entity.Member
 import com.linecorp.kotlinjdsl.querymodel.jpql.sort.Sorts.desc
@@ -19,6 +20,11 @@ interface AlarmCustomRepository {
         size: Int,
         lastAlarmId: Long? = null,
     ): Slice<Alarm>
+
+    fun countByReceiverIdAndIdGreaterThan(
+        receiverId: Long,
+        lastAlarmId: Long?,
+    ): Long
 }
 
 class AlarmCustomRepositoryImpl(
@@ -41,4 +47,23 @@ class AlarmCustomRepositoryImpl(
                 ).orderBy(desc(path(Alarm::id)))
         }
     }
+
+    /**
+     * 마지막으로 읽은 알람을 조회
+     * TODO : 읽지 않은 개수의 상한치 설정 필요
+     */
+    override fun countByReceiverIdAndIdGreaterThan(
+        receiverId: Long,
+        lastAlarmId: Long?,
+    ): Long =
+        kotlinJdslJpqlExecutor.getSingle {
+            select(count(entity(Alarm::class)))
+                .from(entity(Alarm::class))
+                .where(
+                    and(
+                        path(Alarm::receiver).path(Member::id).equal(receiverId),
+                        lastAlarmId?.let { path(Alarm::id).greaterThan(it) },
+                    ),
+                )
+        }
 }

--- a/friends_server/src/main/kotlin/com/friends/alarm/repository/MemberLastReadAlarmRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/alarm/repository/MemberLastReadAlarmRepository.kt
@@ -1,0 +1,8 @@
+package com.friends.alarm.repository
+
+import com.friends.alarm.entity.MemberLastReadAlarm
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberLastReadAlarmRepository : JpaRepository<MemberLastReadAlarm, Long> {
+    fun findByMemberId(memberId: Long): MemberLastReadAlarm?
+}

--- a/friends_server/src/main/kotlin/com/friends/alarm/service/AlarmQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/alarm/service/AlarmQueryService.kt
@@ -1,27 +1,59 @@
 package com.friends.alarm.service
 
 import com.friends.alarm.AlarmResponseDto
+import com.friends.alarm.entity.Alarm
+import com.friends.alarm.entity.MemberLastReadAlarm
 import com.friends.alarm.repository.AlarmRepository
+import com.friends.alarm.repository.MemberLastReadAlarmRepository
 import com.friends.alarm.toAlarmResponseDto
 import com.friends.common.dto.SliceBaseResponse
 import com.friends.common.mapper.toSliceBaseResponse
+import com.friends.member.MemberNotFoundException
+import com.friends.member.repository.MemberRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional(readOnly = true)
 class AlarmQueryService(
+    private val memberRepository: MemberRepository,
     private val alarmRepository: AlarmRepository,
+    private val memberLastReadAlarmRepository: MemberLastReadAlarmRepository,
 ) {
+    @Transactional // 읽지 않은 알람 개수를 조회하기 위해 읽은 알람을 저장하기 때문에 Transactional 필요
     fun getAlarmList(
         memberId: Long,
         size: Int,
         lastAlarmId: Long?,
     ): SliceBaseResponse<AlarmResponseDto> {
-        val result =
-            alarmRepository.findAllByMemberIdBeforeId(memberId, size, lastAlarmId).map {
-                toAlarmResponseDto(it)
-            }
-        return toSliceBaseResponse(result)
+        val result = alarmRepository.findAllByMemberIdBeforeId(memberId, size, lastAlarmId)
+
+        // 마지막으로 읽은 알람을 저장 (읽지 않은 알람 개수를 알기 위함)
+        if (!result.isEmpty) {
+            val lastReadAlarm = result.content.first()
+            saveLastReadAlarm(memberId, lastReadAlarm)
+        }
+
+        return toSliceBaseResponse(result.map { toAlarmResponseDto(it) })
+    }
+
+    // 마지막으로 읽은 알람을 저장 (읽지 않은 알람 개수를 알기 위함)
+    private fun saveLastReadAlarm(
+        memberId: Long,
+        lastReadAlarm: Alarm,
+    ) {
+        val member = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
+        memberLastReadAlarmRepository.save(
+            MemberLastReadAlarm(
+                member = member,
+                alarm = lastReadAlarm,
+            ),
+        )
+    }
+
+    fun getUnreadAlarmCount(memberId: Long): Long {
+        // 마지막으로 읽은 알람을 조회
+        val lastReadAlarm = memberLastReadAlarmRepository.findByMemberId(memberId)
+        return alarmRepository.countByReceiverIdAndIdGreaterThan(memberId, lastReadAlarm?.alarm?.id)
     }
 }


### PR DESCRIPTION
## 📝 Pull Request 내용
읽지 않는 알람 개수를 카운트하는 서비스를 구현하였습니다.

### 📑 변경 사항
- [ ] 유저 별 마지막으로 읽은 알람은 RDB 에 저장하였습니다.
- [ ] 알람을 조회하면 모든 알람을 읽음 처리하고 RDB 에 가장 최근 알람을 저장합니다.
- [ ] 이후 unread-count API 를 호출하면 하면 읽지 않은 알람 개수만 셉니다.
- [ ] 마지막으로 읽은 알람이 없을 경우 모든 알람을 셉니다.

### 🔗 관련 이슈
- 

### 💬 기타 참고 사항
읽지 않은 알람을 모두 카운트하도록 구현했습니다.

현재는 읽지 않은 알람을 모두 세기 때문에 sql 에서 모든 행을 스캔 하게됩니다.
개수의 상한선을 정하고, 캐싱하는 방식으로 API 를 효율화할 수 있을 것 같은데 이슈에 남겨 놓고 구현해보도록 하겠습니다.
