### PR TITLE
feature/chat_room_detail_response

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/dto/ChatRoomResponseDto.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/ChatRoomResponseDto.kt
@@ -43,6 +43,10 @@ data class ChatRoomDetailResponseDto(
     val likeCount: Int,
     @Schema(description = "해당 채팅방 좋아요 여부(좋아요 눌렀을 시, true)")
     val isLike: Boolean,
+    @Schema(description = "유저가 마지막으로 읽은 메세지의 id")
+    val lastReadMessageId: Long?,
+    @Schema(description = "채팅방의 마지막 메세지의 id")
+    val lastMessageId: Long?,
 )
 
 data class ChatRoomRecommendationResponseDto(

--- a/friends_server/src/main/kotlin/com/friends/chat/dto/mapper/ChatRoomResponseMapper.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/dto/mapper/ChatRoomResponseMapper.kt
@@ -43,6 +43,8 @@ class ChatRoomResponseMapper(
         memberCount: Int,
         isLike: Boolean,
         imageUrl: String,
+        lastReadMessageId: Long?,
+        lastMessageId: Long?,
     ) = ChatRoomDetailResponseDto(
         id = chatRoom.id,
         title = chatRoom.title,
@@ -51,6 +53,8 @@ class ChatRoomResponseMapper(
         participantCount = memberCount,
         likeCount = chatRoom.likeCount,
         isLike = isLike,
+        lastReadMessageId = lastReadMessageId,
+        lastMessageId = lastMessageId,
     )
 
     fun toChatRoomMemberInfoResponseDto(

--- a/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomQueryService.kt
@@ -69,8 +69,19 @@ class ChatRoomQueryService(
         memberId: Long,
     ): ChatRoomDetailResponseDto {
         val chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow { throw ChatRoomNotFoundException() }
-        memberRepository.findById(memberId).orElseThrow { throw MemberNotFoundException() }
-        return chatRoomResponseMapper.toChatRoomDetailResponseDto(chatRoom, chatRoomMemberRepository.countByChatRoom(chatRoom), chatRoomLikeRepository.existsByChatRoomAndMemberId(chatRoom, memberId), chatRoom.imageUrl ?: chatRoomBaseImageUrl)
+        val member = memberRepository.findById(memberId).orElseThrow { throw MemberNotFoundException() }
+        val participantCount = chatRoomMemberRepository.countByChatRoom(chatRoom)
+        val isLike = chatRoomLikeRepository.existsByChatRoomAndMemberId(chatRoom, memberId)
+        val lastReadMessageId = chatRoomMemberRepository.findByChatRoomAndMember(chatRoom = chatRoom, member = member)?.lastReadMessage?.id
+        val lastMessage = messageRepository.findRecentMessageInChatRoomWithSystemMessage(chatRoom)
+        return chatRoomResponseMapper.toChatRoomDetailResponseDto(
+            chatRoom = chatRoom,
+            memberCount = participantCount,
+            isLike = isLike,
+            imageUrl = chatRoom.imageUrl ?: chatRoomBaseImageUrl,
+            lastReadMessageId = lastReadMessageId,
+            lastMessageId = lastMessage?.id,
+        )
     }
 
     @Transactional(readOnly = true)
@@ -82,6 +93,7 @@ class ChatRoomQueryService(
         val member = memberRepository.findById(memberId).orElseThrow { throw MemberNotFoundException() }
         return chatRoomMemberRepository.existsChatRoomMemberByChatRoomAndMember(chatRoom, member)
     }
+
     @Transactional(readOnly = true)
     fun getChatRoomMemberInfoList(
         chatRoomId: Long,

--- a/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/repository/MessageRepository.kt
@@ -40,6 +40,8 @@ interface MessageCustomRepository {
     ): Slice<Message>
 
     fun findRecentMessageInChatRoom(chatRoom: ChatRoom): Message?
+
+    fun findRecentMessageInChatRoomWithSystemMessage(chatRoom: ChatRoom): Message?
 }
 
 class MessageCustomRepositoryImpl(
@@ -113,6 +115,15 @@ class MessageCustomRepositoryImpl(
                         path(Message::chatRoom).equal(chatRoom),
                         path(Message::type).`in`(MessageType.getNonSystemTypes()),
                     ),
+                ).orderBy(path(Message::id).desc())
+        }
+
+    override fun findRecentMessageInChatRoomWithSystemMessage(chatRoom: ChatRoom): Message? =
+        kotlinJdslJpqlExecutor.find {
+            select(entity(Message::class))
+                .from(entity(Message::class))
+                .where(
+                    path(Message::chatRoom).equal(chatRoom),
                 ).orderBy(path(Message::id).desc())
         }
 }

--- a/friends_server/src/test/kotlin/com/friends/chat/ChatFixture.kt
+++ b/friends_server/src/test/kotlin/com/friends/chat/ChatFixture.kt
@@ -85,7 +85,7 @@ fun createTestChatRoomDetailResponseDto(
     memberCount: Int = TEST_SIZE,
     like: Boolean = false,
     imageUrl: String = CHAT_ROOM_BASE_IMAGE_URL,
-) = mapper.toChatRoomDetailResponseDto(chatRoom, memberCount, like, imageUrl)
+) = mapper.toChatRoomDetailResponseDto(chatRoom, memberCount, like, imageUrl, null, null)
 
 fun createTestCreateChatRoomResponseDto(
     chatRoomId: Long = TEST_CHAT_ROOM_ID,

--- a/friends_server/src/test/kotlin/com/friends/chat/service/ChatRoomQueryServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/chat/service/ChatRoomQueryServiceTest.kt
@@ -91,6 +91,8 @@ class ChatRoomQueryServiceTest :
                     every { chatRoomMemberRepository.countByChatRoom(any()) } returns 10
                     every { chatRoomRepository.findById(any()) } returns Optional.of(createTestChatRoom())
                     every { chatRoomLikeRepository.existsByChatRoomAndMemberId(any(), any()) } returns true
+                    every { chatRoomMemberRepository.findByChatRoomAndMember(any(), any()) } returns null
+                    every { messageRepository.findRecentMessageInChatRoom(any()) } returns null
                     then("채팅방이 조회된다.") {
                         chatRoomQueryService.getChatRoomDetail(TEST_CHAT_ROOM_ID, MEMBER_ID)
                     }


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] 채팅방 세부 조회 response dto 에 마지막으로 읽은 메세지의 id 와 채팅방의 최신 메세지 id 를 추가하였습니다.
- [ ] 채팅방의 최신 메세지의 경우 SYSTEM 메세지를 포함하도록 설정하였습니다.
- [ ] 추가된 기능에 따라 테스트를 수정하였습니다.

### 🔗 관련 이슈
- 

### 💬 기타 참고 사항
기존 채팅방의 최신 메세지 조회 메서드를 재사용하지 않고 SYSTEM 메세지를 포함하여 최신 메세지를 찾는 메서드를 추가하였습니다.

기존 채팅방의 최신 메세지 조회는 채팅방 리스트의 마지막 메세지를 조회하는데 사용되었고,
이때 시스템 메세지는 포함되지 않아야 하기 때문에 제외했습니다.

채팅방 세부 조회 시 에는 클라이언트에서 마지막으로 읽은 메세지의 id 와 최신 메세지의 id 를 비교하여
같다면 이전 메세지를 조회하고 다르다면 읽지 않은 메세지를 조회합니다.
이때 마지막으로 읽은 메세지의 id 는 SYSTEM 메세지도 포함하기 때문에 올바른 비교를 위해 최신 메세제의 id 에도 시스템 메세지가 포함되도록 구현하였습니다.
