### PR TITLE
Feature/reset password

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
+++ b/friends_server/src/main/kotlin/com/friends/common/exception/ErrorCode.kt
@@ -24,6 +24,7 @@ enum class ErrorCode(
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST, -11007, "유효하지 않은 닉네임입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, -11008, "인증되지 않은 사용자입니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, -11009, "권한이 없습니다."),
+    DUPLICATE_NEW_PASSWORD(HttpStatus.BAD_REQUEST, -11010, "새 비밀번호가 이전 비밀번호와 동일합니다."),
 
     // Member API error 12000대
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, -12001, "존재하지 않는 회원입니다."),

--- a/friends_server/src/main/kotlin/com/friends/member/entity/MemberEntities.kt
+++ b/friends_server/src/main/kotlin/com/friends/member/entity/MemberEntities.kt
@@ -29,7 +29,7 @@ class Member(
     // 이메일은 중복되지 않아야 하며 수정되지 않아야 합니다.
     @Column(unique = true, updatable = false)
     val email: String,
-    var password: String? = null,
+    private var password: String? = null,
     @Enumerated(EnumType.STRING)
     var oauth2Provider: OAuth2Provider?,
     // 권한 리스트는 기본적으로 비어 있는 리스트로 초기화
@@ -92,6 +92,12 @@ class Member(
 
     fun updateNickname(nickname: String) {
         this.nickname = nickname
+    }
+
+    fun getPassword(): String? = password
+
+    fun updatePassword(newPassword: String) {
+        this.password = newPassword
     }
 }
 

--- a/friends_server/src/main/kotlin/com/friends/security/securityException/InvalidTokenException.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/securityException/InvalidTokenException.kt
@@ -22,4 +22,6 @@ class EmailDuplicateException : AuthenticationException(ErrorCode.EMAIL_ALREADY_
 
 class InvalidPasswordException : AuthenticationException(ErrorCode.INVALID_PASSWORD)
 
+class DuplicateNewPasswordException : AuthenticationException(ErrorCode.DUPLICATE_NEW_PASSWORD)
+
 class InvalidNicknameException : AuthenticationException(ErrorCode.INVALID_NICKNAME)

--- a/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
@@ -252,8 +252,7 @@ class AuthService(
             throw DuplicateNewPasswordException()
         }
 
-        // jwt 에서 email 을 추출하고 해당 email 을 가진 사용자의 비밀번호를 변경합니다.
+        // 비밀번호 업데이트
         member.updatePassword(passwordEncoder.encode(newPassword))
-        memberRepository.save(member)
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
@@ -248,12 +248,12 @@ class AuthService(
             throw InvalidPasswordException()
         }
         // 새 비밀번호와 기존 비밀번호가 같은지 검사
-        if (passwordEncoder.matches(newPassword, member.password)) {
+        if (passwordEncoder.matches(newPassword, member.getPassword())) {
             throw DuplicateNewPasswordException()
         }
 
         // jwt 에서 email 을 추출하고 해당 email 을 가진 사용자의 비밀번호를 변경합니다.
-        member.password = passwordEncoder.encode(newPassword)
+        member.updatePassword(passwordEncoder.encode(newPassword))
         memberRepository.save(member)
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/service/AuthService.kt
@@ -21,6 +21,7 @@ import com.friends.security.CheckEmailResponseDto
 import com.friends.security.CheckNicknameResponseDto
 import com.friends.security.OAuth2LoginDto
 import com.friends.security.RegisterRequestDto
+import com.friends.security.securityException.DuplicateNewPasswordException
 import com.friends.security.securityException.EmailDuplicateException
 import com.friends.security.securityException.EmailNotFoundException
 import com.friends.security.securityException.InvalidNicknameException
@@ -236,12 +237,23 @@ class AuthService(
         if (!jwtService.validate(emailAuthToken)) {
             throw InvalidTokenException()
         }
+        val emailFromToken = jwtService.getClaim(emailAuthToken, "email", String::class.java) ?: throw InvalidTokenException()
+
+        // 유저 존재 여부 확인
+        val member = memberRepository.findByEmail(emailFromToken) ?: throw EmailNotFoundException()
+
+        // 패스워드 유효성 검사
+        // 적절한 비밀번호 패턴인지 검사
+        if (!validatePassword(newPassword)) {
+            throw InvalidPasswordException()
+        }
+        // 새 비밀번호와 기존 비밀번호가 같은지 검사
+        if (passwordEncoder.matches(newPassword, member.password)) {
+            throw DuplicateNewPasswordException()
+        }
 
         // jwt 에서 email 을 추출하고 해당 email 을 가진 사용자의 비밀번호를 변경합니다.
-        val emailFromToken = jwtService.getClaim(emailAuthToken, "email", String::class.java) ?: throw InvalidTokenException()
-        memberRepository.findByEmail(emailFromToken)?.apply {
-            password = passwordEncoder.encode(newPassword)
-            memberRepository.save(this)
-        } ?: throw EmailNotFoundException()
+        member.password = passwordEncoder.encode(newPassword)
+        memberRepository.save(member)
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/security/userDetails/CustomUserDetails.kt
+++ b/friends_server/src/main/kotlin/com/friends/security/userDetails/CustomUserDetails.kt
@@ -17,7 +17,7 @@ class CustomUserDetails(
 
     override fun getAuthorities(): Collection<GrantedAuthority> = authorities
 
-    override fun getPassword(): String? = member.password
+    override fun getPassword(): String? = member.getPassword()
 
     override fun getUsername(): String = member.email
 


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] 비밀번호 변경 시에 유효성 검사를 추가하였습니다. (패턴 검사, 이전 비밀번호와 동일 여부 검사)
- [ ] Member 앤티티의 비밀번호를 private 으로 바꾸고 비밀번호 업데이트 메서드를 추가하였습니다.

### 🔗 관련 이슈
- 

### 💬 기타 참고 사항
테스트를 진행하려고 했더니 authService 가 너무 많은 의존성을 가지고 있어서 쉽지 않네요!
일단 통합 테스트 시 비밀번호 유효성검사가 성공적으로 작동하는 것을 확인하였습니다.
바로 다음 작업에  authService 를 리펙토링 하고 테스트 작업까지 해보겠습니다..!
