### PR TITLE
Feature/message content size

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/websocket/ChatWebSocketHandler.kt
@@ -8,12 +8,15 @@ import com.friends.chat.dto.PingPongType
 import com.friends.chat.repository.PingPongRepository
 import com.friends.common.util.JsonUtil
 import com.friends.message.service.MessageCommandService
+import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.CloseStatus
 import org.springframework.web.socket.TextMessage
 import org.springframework.web.socket.WebSocketSession
 import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator
 import org.springframework.web.socket.handler.TextWebSocketHandler
+
+private val logger = KotlinLogging.logger {}
 
 @Component
 class ChatWebSocketHandler(
@@ -23,11 +26,13 @@ class ChatWebSocketHandler(
     companion object {
         private const val SEND_TIME_LIMIT = 2000 // 2초
         private const val BUFFER_SIZE_LIMIT = 1024 * 1024 // 1MB
+        private const val TEXT_MAX_SIZE = 1 * 1024 * 1024 // 1MB
     }
 
     override fun afterConnectionEstablished(session: WebSocketSession) {
         try {
             val memberId = getMemberId(session)
+            session.textMessageSizeLimit = TEXT_MAX_SIZE
             messageCommandService.setAllChatRoomsOnline(memberId, ConcurrentWebSocketSessionDecorator(session, SEND_TIME_LIMIT, BUFFER_SIZE_LIMIT))
         } catch (e: Exception) {
             session.close(CloseStatus.SERVER_ERROR)// 채팅방 연결 종료 후 에러 처리
@@ -54,6 +59,7 @@ class ChatWebSocketHandler(
             try {
                 JsonUtil.fromJson<ChatReceiveMessageDto>(message.payload)
             } catch (e: Exception) {
+                logger.error(e) { "메세지 전송 양식이 부적절합니다. " + message.payload }
                 val chatErrorMessageDto =
                     ChatErrorMessageDto(
                         clientMessageId = null,

--- a/friends_server/src/main/kotlin/com/friends/message/entity/Message.kt
+++ b/friends_server/src/main/kotlin/com/friends/message/entity/Message.kt
@@ -24,7 +24,7 @@ class Message(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id", nullable = false, updatable = false)
     val sender: Member,
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     var content: String,
     @Column(nullable = false)
     var type: MessageType,


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] 메세지 앤티티의 content 칼럼의 스키마를 varchat(255) 에서 text 로 변경하였습니다.
- [ ] 웹소켓 핸들러의 전송 크기 제한을 8kb 에서 1mb 로 변경하였습니다.

### 🔗 관련 이슈

### 💬 기타 참고 사항
아래와 같이 로그를 찍어 확인해봤더니 웹소켓 메세지 크기 제한이 8kb 더라구요.
이를 1mb 로 변경하였습니다.

![스크린샷 2025-02-04 오후 7 16 04](https://github.com/user-attachments/assets/673bbe8e-ae16-47b7-9c8b-f8b4fb3eb0a8)
![스크린샷 2025-02-04 오후 7 16 09](https://github.com/user-attachments/assets/16ab8bbc-f7e1-4901-be4e-6e3713a4c949)

(authService 리펙토링 작업을 진행 중에 있는데 생각보다 고려할게 많아서 시간이 약간 더 걸릴 것 같네요 🥺 )