### PR TITLE
fix : last read alarm 을 업데이트하지 않고 매번 새로 저장하는 에러 해결

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/alarm/entity/MemberLastReadAlarm.kt
+++ b/friends_server/src/main/kotlin/com/friends/alarm/entity/MemberLastReadAlarm.kt
@@ -18,5 +18,5 @@ class MemberLastReadAlarm(
     val member: Member,
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "alarm_id")
-    val alarm: Alarm,
+    var alarm: Alarm,
 )

--- a/friends_server/src/main/kotlin/com/friends/alarm/service/AlarmQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/alarm/service/AlarmQueryService.kt
@@ -32,24 +32,27 @@ class AlarmQueryService(
         // 마지막으로 읽은 알람을 저장 (읽지 않은 알람 개수를 알기 위함)
         if (!result.isEmpty) {
             val lastReadAlarm = result.content.first()
-            saveLastReadAlarm(memberId, lastReadAlarm)
+            updateLastReadAlarm(memberId, lastReadAlarm)
         }
 
         return toSliceBaseResponse(result.map { toAlarmResponseDto(it) })
     }
 
     // 마지막으로 읽은 알람을 저장 (읽지 않은 알람 개수를 알기 위함)
-    private fun saveLastReadAlarm(
+    private fun updateLastReadAlarm(
         memberId: Long,
         lastReadAlarm: Alarm,
     ) {
         val member = memberRepository.findById(memberId).orElseThrow { MemberNotFoundException() }
-        memberLastReadAlarmRepository.save(
-            MemberLastReadAlarm(
-                member = member,
-                alarm = lastReadAlarm,
-            ),
-        )
+        val memberLastReadAlarm =
+            memberLastReadAlarmRepository.findByMemberId(memberId)
+                ?: memberLastReadAlarmRepository.save(
+                    MemberLastReadAlarm(
+                        member = member,
+                        alarm = lastReadAlarm,
+                    ),
+                )
+        memberLastReadAlarm.alarm = lastReadAlarm
     }
 
     fun getUnreadAlarmCount(memberId: Long): Long {


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] 마지막으로 읽은 알람의 앤티티가 업데이트 되지 않고 매번 새롭게 생성되면서
일대일 매핑에서 FK 가 중복 생성되어 에러가 발생하던 현상을 해결하였습니다.

### 🔗 관련 이슈

### 💬 기타 참고 사항
- 
