### PR TITLE
Fix/chating invite list

### DIFF
--- a/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/repository/ChatRoomMemberRepository.kt
@@ -46,7 +46,7 @@ interface ChatRoomMemberRepository :
 interface ChatRoomMemberCustomRepository {
     fun findAllByMemberAndFriends(
         memberId: Long,
-        memberList: List<Member>?,
+        memberList: Set<Member>?,
     ): List<ChatRoomMember>
 
     fun findRepresentativeProfileByChatRoomId(chatRoomId: Long): List<Member>
@@ -63,7 +63,7 @@ class ChatRoomMemberCustomRepositoryImpl(
 ) : ChatRoomMemberCustomRepository {
     override fun findAllByMemberAndFriends(
         memberId: Long,
-        memberList: List<Member>?,
+        memberList: Set<Member>?,
     ): List<ChatRoomMember> =
         kotlinJdslJpqlExecutor.getList {
             select(entity(ChatRoomMember::class)) // 중복 제거
@@ -102,7 +102,7 @@ class ChatRoomMemberCustomRepositoryImpl(
         }
 
     private fun Jpql.dynamicChatRoomList(
-        memberList: List<Member>?,
+        memberList: Set<Member>?,
     ): Predicate? =
         if (memberList == null) {
             null

--- a/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/chat/service/ChatRoomQueryService.kt
@@ -40,7 +40,7 @@ class ChatRoomQueryService(
         nickname: String?,
     ): List<ChatRoomInfoResponseDto> {
         memberRepository.findById(memberId).orElseThrow { throw MemberNotFoundException() }
-        val friends: List<Member>? =
+        val friends: Set<Member>? =
             if (nickname != null) {
                 friendshipRepository.findFriendshipByMemberIdAndNickname(memberId, nickname).also { if (it.isEmpty()) return emptyList() }
             } else {

--- a/friends_server/src/main/kotlin/com/friends/friendship/repository/FriendShipRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/friendship/repository/FriendShipRepository.kt
@@ -34,11 +34,11 @@ interface FriendShipCustomRepository {
     fun findFriendshipByMemberIdAndNickname(
         memberId: Long,
         nickname: String?,
-    ): List<Member>
+    ): Set<Member>
 
     fun findFriendAndBlockedByMemberId(
         memberId: Long,
-    ): List<Member>
+    ): Set<Member>
 }
 
 class FriendShipCustomRepositoryImpl(
@@ -65,7 +65,7 @@ class FriendShipCustomRepositoryImpl(
     override fun findFriendshipByMemberIdAndNickname(
         memberId: Long,
         nickname: String?,
-    ): List<Member> {
+    ): Set<Member> {
         val result1 =
             kotlinJdslJpqlExecutor.getList {
                 select(path(Friendship::requester))
@@ -93,12 +93,12 @@ class FriendShipCustomRepositoryImpl(
                     )
             }
 
-        return result1 + result2
+        return (result1 + result2).toSet()
     }
 
     override fun findFriendAndBlockedByMemberId(
         memberId: Long,
-    ): List<Member> {
+    ): Set<Member> {
         val result1 =
             kotlinJdslJpqlExecutor.getList {
                 select(path(Friendship::requester))
@@ -127,6 +127,6 @@ class FriendShipCustomRepositoryImpl(
                         ),
                     )
             }
-        return result1 + result2
+        return (result1 + result2).toSet()
     }
 }

--- a/friends_server/src/main/kotlin/com/friends/friendship/service/FriendShipQueryService.kt
+++ b/friends_server/src/main/kotlin/com/friends/friendship/service/FriendShipQueryService.kt
@@ -24,7 +24,7 @@ class FriendShipQueryService(
         nickname: String?,
     ): List<ProfileSimpleResponseDto> {
         // 친구 관계가 맺어진 사람들 중 닉네임으로 검색 (닉네임이 null 이라면 전체 검색)
-        val friends = friendShipRepository.findFriendshipByMemberIdAndNickname(chatRoomId, nickname)
+        val friends = friendShipRepository.findFriendshipByMemberIdAndNickname(memberId, nickname)
 
         // 채팅방에 속한 사람 조회
         val usersInChatRoom = chatRoomMemberRepository.findAllByChatRoomId(chatRoomId)

--- a/friends_server/src/main/kotlin/com/friends/profile/repository/ProfileRepository.kt
+++ b/friends_server/src/main/kotlin/com/friends/profile/repository/ProfileRepository.kt
@@ -60,7 +60,7 @@ interface ProfileRepository :
     )
     fun findRandomProfileExcludeFriend(
         pageable: Pageable,
-        friendAndBlocked: List<Member>,
+        friendAndBlocked: Set<Member>,
         member: Member,
     ): List<Profile>
 }

--- a/friends_server/src/test/kotlin/com/friends/chat/repository/ChatRoomMemberRepositoryTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/chat/repository/ChatRoomMemberRepositoryTest.kt
@@ -76,7 +76,7 @@ class ChatRoomMemberRepositoryTest(
 
             context("회원 ID 리스트를 받으면") {
                 it("chatRoomMember를 전부 반환한다") {
-                    chatRoomMemberRepository.findAllByMemberAndFriends(member2.id, listOf(member1, member3)) shouldBe listOf(chatRoomMember2)
+                    chatRoomMemberRepository.findAllByMemberAndFriends(member2.id, setOf(member1, member3)) shouldBe listOf(chatRoomMember2)
                 }
             }
         }

--- a/friends_server/src/test/kotlin/com/friends/chat/service/ChatRoomQueryServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/chat/service/ChatRoomQueryServiceTest.kt
@@ -64,7 +64,7 @@ class ChatRoomQueryServiceTest :
                 }
 
                 `when`("친구 중 해당 닉네임을 가진 친구가 없는 경우") {
-                    every { friendshipRepository.findFriendshipByMemberIdAndNickname(any(), any()) } returns emptyList()
+                    every { friendshipRepository.findFriendshipByMemberIdAndNickname(any(), any()) } returns emptySet()
                     then("빈 리스트가 반환된다.") {
                         chatRoomQueryService.getChatRooms(MEMBER_ID, "test")
                         verify(exactly = 0) {

--- a/friends_server/src/test/kotlin/com/friends/profile/repository/ProfileRepositoryTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/profile/repository/ProfileRepositoryTest.kt
@@ -89,7 +89,7 @@ class ProfileRepositoryTest
         @Test
         fun `친구를 제외한 랜덤 프로필 조회`() {
             val pageable = PageRequest.of(0, 3)
-            val profiles = profileRepository.findRandomProfileExcludeFriend(pageable, listOf(profile1.member), profile2.member)
+            val profiles = profileRepository.findRandomProfileExcludeFriend(pageable, setOf(profile1.member), profile2.member)
             profiles shouldNotContain profile1
             profiles shouldNotContain profile2
             profiles.size shouldBe 3
@@ -98,7 +98,7 @@ class ProfileRepositoryTest
         @Test
         fun `친구가 없는 경우 랜덤 프로필 조회`() {
             val pageable = PageRequest.of(0, 200)
-            val profiles = profileRepository.findRandomProfileExcludeFriend(pageable, emptyList(), profile1.member)
+            val profiles = profileRepository.findRandomProfileExcludeFriend(pageable, emptySet(), profile1.member)
             profiles shouldNotContain profile1
             profiles shouldContain profile2
             profiles shouldContain profile4

--- a/friends_server/src/test/kotlin/com/friends/recommendation/service/UserRecommendationServiceTest.kt
+++ b/friends_server/src/test/kotlin/com/friends/recommendation/service/UserRecommendationServiceTest.kt
@@ -27,7 +27,7 @@ class UserRecommendationServiceIntegrationTest :
             val requesterProfile = createTestProfile(requester)
             val member = createTestMember(email = "test2")
             val memberProfile = createTestProfile(member)
-            every { friendShipRepository.findFriendAndBlockedByMemberId(any()) } returns emptyList()
+            every { friendShipRepository.findFriendAndBlockedByMemberId(any()) } returns emptySet()
             `when`("랜덤 추천을 요청 후 해당 유저에게 친구 요청을 보낸 경우") {
                 every { profileRepository.findByMemberId(any()) } returns requesterProfile
                 every { profileRepository.findRandomProfileExcludeFriend(any(), any(), any()) } returns listOf(memberProfile)


### PR DESCRIPTION
## 📝 Pull Request 내용

### 📑 변경 사항
- [ ] memberId 부분에 잘못 들어간 필드 수정
- [ ] 중복 유저 제외하도록 Set 수정
- [ ] 해당 메서드쓰는 곳 전부 Set으로 수정

### 💬 기타 참고 사항
- 저희 서비스는 이미 친구이거나 친구 신청이 있으면 신청을 못 보내게 되어있어, receiver =1 requester =2 (Accept) / receiver =1 requester =2 (Accept)가 존재할 수 없을 거 같습니다. 굳이 중복 제거를 할 필요가 없을 거 같다고 생각했습니다. 
하지만 더미 데이터로 넣다보니 해당 상황이 생겨서 중복 유저가 나옵니다. 프론트분들 작업 편의를 위해 set을 통해 중복 제거를 했습니다!